### PR TITLE
fix(account): search user by email only

### DIFF
--- a/account/accountusecase/accountinteractor/user.go
+++ b/account/accountusecase/accountinteractor/user.go
@@ -70,8 +70,8 @@ func (i *User) FetchBySub(ctx context.Context, sub string) (*user.User, error) {
 	return i.query.FetchBySub(ctx, sub)
 }
 
-func (i *User) SearchUser(ctx context.Context, nameOrEmail string) (*user.Simple, error) {
-	return i.query.SearchUser(ctx, nameOrEmail)
+func (i *User) SearchUser(ctx context.Context, email string) (*user.Simple, error) {
+	return i.query.SearchUser(ctx, email)
 }
 
 func (i *User) GetUserByCredentials(ctx context.Context, inp accountinterfaces.GetUserByCredentials) (u *user.User, err error) {
@@ -407,9 +407,9 @@ func (q *UserQuery) FetchBySub(ctx context.Context, sub string) (*user.User, err
 	return nil, rerror.ErrNotFound
 }
 
-func (q *UserQuery) SearchUser(ctx context.Context, nameOrEmail string) (*user.Simple, error) {
+func (q *UserQuery) SearchUser(ctx context.Context, email string) (*user.Simple, error) {
 	for _, r := range q.repos {
-		u, err := r.FindByNameOrEmail(ctx, nameOrEmail)
+		u, err := r.FindByEmail(ctx, email)
 		if errors.Is(err, rerror.ErrNotFound) {
 			continue
 		}

--- a/account/accountusecase/accountproxy/operations.graphql
+++ b/account/accountusecase/accountproxy/operations.graphql
@@ -30,8 +30,8 @@ query UserByIDs($id: [ID!]!) {
   }
 }
 
-query SearchUser($nameOrEmail: String!) {
-  searchUser(nameOrEmail: $nameOrEmail) {
+query SearchUser($email: String!) {
+  searchUser(email: $email) {
      ...FragmentUser
   }
 }

--- a/account/accountusecase/accountproxy/user.go
+++ b/account/accountusecase/accountproxy/user.go
@@ -104,8 +104,8 @@ func (u *User) RemoveMyAuth(ctx context.Context, auth string, op *accountusecase
 	return MeToUser(res.RemoveMyAuth.Me.FragmentMe)
 }
 
-func (u *User) SearchUser(ctx context.Context, nameOrEmail string) (*user.Simple, error) {
-	res, err := SearchUser(ctx, u.gql, nameOrEmail)
+func (u *User) SearchUser(ctx context.Context, email string) (*user.Simple, error) {
+	res, err := SearchUser(ctx, u.gql, email)
 	if err != nil {
 		return nil, err
 	}

--- a/account/user.graphql
+++ b/account/user.graphql
@@ -82,7 +82,7 @@ input DeleteMeInput {
 
 extend type Query {
   me: Me
-  searchUser(nameOrEmail: String!): User
+  searchUser(email: String!): User
 }
 
 type UserPayload {


### PR DESCRIPTION
`SearchUser` currently accepts `name` or `email` and returns 1 user. This is problematic because there can be more than 1 user with the same name. 

Although it's convenient to search users by their `name` but it can lead to wrong results. 
`email` is unique and also a standard practise to `search` for users on a platform. 

hence the change from `SearchUser(emailOrName) => SearchUser(email)` 

