### PR TITLE
feat(account): remove multiple user-members from workspace

### DIFF
--- a/account/accountdomain/workspace/member.go
+++ b/account/accountdomain/workspace/member.go
@@ -15,6 +15,7 @@ var (
 	ErrCannotModifyPersonalWorkspace = rerror.NewE(i18n.T("personal workspace cannot be modified"))
 	ErrTargetUserNotInTheWorkspace   = rerror.NewE(i18n.T("target user does not exist in the workspace"))
 	ErrInvalidWorkspaceName          = rerror.NewE(i18n.T("invalid workspace name"))
+	ErrNoSpecifiedUsers              = rerror.NewE(i18n.T("no specified users for removal"))
 )
 
 type Member struct {

--- a/account/accountusecase/accountinteractor/workspace.go
+++ b/account/accountusecase/accountinteractor/workspace.go
@@ -227,7 +227,7 @@ func (i *Workspace) RemoveUserMember(ctx context.Context, id workspace.ID, u wor
 	})
 }
 
-func (i *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.ID, userIDs workspace.UserIDList, operator *accountusecase.Operator) (_ *workspace.Workspace, err error) {
+func (i *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.ID, userIds workspace.UserIDList, operator *accountusecase.Operator) (_ *workspace.Workspace, err error) {
 	if operator.User == nil {
 		return nil, accountinterfaces.ErrInvalidOperator
 	}
@@ -244,17 +244,17 @@ func (i *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.
 
 		isOwner := ws.Members().UserRole(*operator.User) == workspace.RoleOwner
 
-		for _, u := range userIDs {
-			isSelfLeave := *operator.User == u
+		for _, uId := range userIds {
+			isSelfLeave := *operator.User == uId
 
 			if !isOwner && !isSelfLeave {
 				return nil, accountinterfaces.ErrOperationDenied
 			}
-			if isSelfLeave && ws.Members().IsOnlyOwner(u) {
+			if isSelfLeave && ws.Members().IsOnlyOwner(uId) {
 				return nil, accountinterfaces.ErrOwnerCannotLeaveTheWorkspace
 			}
 
-			err := ws.Members().Leave(u)
+			err := ws.Members().Leave(uId)
 			if err != nil {
 				return nil, err
 			}

--- a/account/accountusecase/accountinteractor/workspace.go
+++ b/account/accountusecase/accountinteractor/workspace.go
@@ -233,7 +233,7 @@ func (i *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.
 	}
 
 	if userIds.Len() == 0 {
-		return nil, accountinterfaces.ErrNoSpecifiedUsers
+		return nil, workspace.ErrNoSpecifiedUsers
 	}
 
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (*workspace.Workspace, error) {

--- a/account/accountusecase/accountinteractor/workspace.go
+++ b/account/accountusecase/accountinteractor/workspace.go
@@ -233,7 +233,7 @@ func (i *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.
 	}
 
 	if userIds.Len() == 0 {
-		return nil, accountinterfaces.ErrNoUsersSpecified
+		return nil, accountinterfaces.ErrNoSpecifiedUsers
 	}
 
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (*workspace.Workspace, error) {

--- a/account/accountusecase/accountinteractor/workspace.go
+++ b/account/accountusecase/accountinteractor/workspace.go
@@ -232,6 +232,10 @@ func (i *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.
 		return nil, accountinterfaces.ErrInvalidOperator
 	}
 
+	if userIds.Len() == 0 {
+		return nil, accountinterfaces.ErrNoUsersSpecified
+	}
+
 	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (*workspace.Workspace, error) {
 		ws, err := i.repos.Workspace.FindByID(ctx, id)
 		if err != nil {

--- a/account/accountusecase/accountinteractor/workspace.go
+++ b/account/accountusecase/accountinteractor/workspace.go
@@ -227,6 +227,49 @@ func (i *Workspace) RemoveUserMember(ctx context.Context, id workspace.ID, u wor
 	})
 }
 
+func (i *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.ID, userIDs workspace.UserIDList, operator *accountusecase.Operator) (_ *workspace.Workspace, err error) {
+	if operator.User == nil {
+		return nil, accountinterfaces.ErrInvalidOperator
+	}
+
+	return Run1(ctx, operator, i.repos, Usecase().Transaction(), func(ctx context.Context) (*workspace.Workspace, error) {
+		ws, err := i.repos.Workspace.FindByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		if ws.IsPersonal() {
+			return nil, workspace.ErrCannotModifyPersonalWorkspace
+		}
+
+		isOwner := ws.Members().UserRole(*operator.User) == workspace.RoleOwner
+
+		for _, u := range userIDs {
+			isSelfLeave := *operator.User == u
+
+			if !isOwner && !isSelfLeave {
+				return nil, accountinterfaces.ErrOperationDenied
+			}
+			if isSelfLeave && ws.Members().IsOnlyOwner(u) {
+				return nil, accountinterfaces.ErrOwnerCannotLeaveTheWorkspace
+			}
+
+			err := ws.Members().Leave(u)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		err = i.repos.Workspace.Save(ctx, ws)
+		if err != nil {
+			return nil, err
+		}
+
+		i.applyDefaultPolicy(ws, operator)
+		return ws, nil
+	})
+}
+
 func (i *Workspace) RemoveIntegration(ctx context.Context, wId workspace.ID, iId workspace.IntegrationID, operator *accountusecase.Operator) (_ *workspace.Workspace, err error) {
 	if operator.User == nil {
 		return nil, accountinterfaces.ErrInvalidOperator

--- a/account/accountusecase/accountinteractor/workspace_test.go
+++ b/account/accountusecase/accountinteractor/workspace_test.go
@@ -1060,7 +1060,7 @@ func TestWorkspace_RemoveMultipleMembers(t *testing.T) {
 				uIds:     workspace.UserIDList{},
 				operator: op,
 			},
-			wantErr: accountinterfaces.ErrNoSpecifiedUsers,
+			wantErr: workspace.ErrNoSpecifiedUsers,
 			want: workspace.NewMembersWith(map[user.ID]workspace.Member{
 				userID: {Role: workspace.RoleOwner},
 				userID2: {Role: workspace.RoleReader},

--- a/account/accountusecase/accountinteractor/workspace_test.go
+++ b/account/accountusecase/accountinteractor/workspace_test.go
@@ -1023,6 +1023,10 @@ func TestWorkspace_RemoveMultipleMembers(t *testing.T) {
 				operator: op,
 			},
 			wantErr: workspace.ErrCannotModifyPersonalWorkspace,
+			want: workspace.NewMembersWith(map[user.ID]workspace.Member{
+				userID: {Role: workspace.RoleOwner},
+				userID2: {Role: workspace.RoleReader},
+			}, nil, false),
 		},
 		{
 			name:       "Remove multiple members, cannot remove owner",
@@ -1038,9 +1042,13 @@ func TestWorkspace_RemoveMultipleMembers(t *testing.T) {
 				operator: op,
 			},
 			wantErr: accountinterfaces.ErrOwnerCannotLeaveTheWorkspace,
+			want: workspace.NewMembersWith(map[user.ID]workspace.Member{
+				userID: {Role: workspace.RoleOwner},
+				userID2: {Role: workspace.RoleReader},
+			}, nil, false),
 		},
 		{
-			name:       "Empty user id list",
+			name:       "Remove multiple members, empty user id list",
 			seeds:      workspace.List{w4},
 			usersSeeds: []*user.User{u, u2},
 			args: struct {
@@ -1053,6 +1061,10 @@ func TestWorkspace_RemoveMultipleMembers(t *testing.T) {
 				operator: op,
 			},
 			wantErr: accountinterfaces.ErrNoSpecifiedUsers,
+			want: workspace.NewMembersWith(map[user.ID]workspace.Member{
+				userID: {Role: workspace.RoleOwner},
+				userID2: {Role: workspace.RoleReader},
+			}, nil, false),
 		},
 		{
 			name: "mock error",
@@ -1091,7 +1103,7 @@ func TestWorkspace_RemoveMultipleMembers(t *testing.T) {
 
 			got, err := workspaceUC.RemoveMultipleUserMembers(ctx, tc.args.wId, tc.args.uIds, tc.args.operator)
 			if tc.wantErr != nil {
-				assert.Equal(t, tc.wantErr, err)
+				assert.ErrorIs(t, tc.wantErr, err)
 				return
 			}
 			assert.NoError(t, err)

--- a/account/accountusecase/accountinterfaces/common.go
+++ b/account/accountusecase/accountinterfaces/common.go
@@ -8,5 +8,4 @@ import (
 var (
 	ErrOperationDenied error = rerror.NewE(i18n.T("operation denied"))
 	ErrInvalidOperator error = rerror.NewE(i18n.T("invalid operator"))
-	ErrNoSpecifiedUsers error = rerror.NewE(i18n.T("no specified users for removal"))
 )

--- a/account/accountusecase/accountinterfaces/common.go
+++ b/account/accountusecase/accountinterfaces/common.go
@@ -8,5 +8,5 @@ import (
 var (
 	ErrOperationDenied error = rerror.NewE(i18n.T("operation denied"))
 	ErrInvalidOperator error = rerror.NewE(i18n.T("invalid operator"))
-	ErrNoUsersSpecified error = rerror.NewE(i18n.T("no users specified for removal"))
+	ErrNoSpecifiedUsers error = rerror.NewE(i18n.T("no specified users for removal"))
 )

--- a/account/accountusecase/accountinterfaces/common.go
+++ b/account/accountusecase/accountinterfaces/common.go
@@ -8,4 +8,5 @@ import (
 var (
 	ErrOperationDenied error = rerror.NewE(i18n.T("operation denied"))
 	ErrInvalidOperator error = rerror.NewE(i18n.T("invalid operator"))
+	ErrNoUsersSpecified error = rerror.NewE(i18n.T("no users specified for removal"))
 )

--- a/account/accountusecase/accountinterfaces/workspace.go
+++ b/account/accountusecase/accountinterfaces/workspace.go
@@ -27,6 +27,7 @@ type Workspace interface {
 	UpdateUserMember(context.Context, workspace.ID, user.ID, workspace.Role, *accountusecase.Operator) (*workspace.Workspace, error)
 	UpdateIntegration(context.Context, workspace.ID, workspace.IntegrationID, workspace.Role, *accountusecase.Operator) (*workspace.Workspace, error)
 	RemoveUserMember(context.Context, workspace.ID, user.ID, *accountusecase.Operator) (*workspace.Workspace, error)
+	RemoveMultipleUserMembers(context.Context, workspace.ID, user.IDList, *accountusecase.Operator) (*workspace.Workspace, error)
 	RemoveIntegration(context.Context, workspace.ID, workspace.IntegrationID, *accountusecase.Operator) (*workspace.Workspace, error)
 	Remove(context.Context, workspace.ID, *accountusecase.Operator) error
 }

--- a/account/accountusecase/accountproxy/generated.go
+++ b/account/accountusecase/accountproxy/generated.go
@@ -108,7 +108,7 @@ func (v *AddIntegrationToWorkspaceAddIntegrationToWorkspaceAddUsersToWorkspacePa
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal AddIntegrationToWorkspaceAddIntegrationToWorkspaceAddUsersToWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal AddIntegrationToWorkspaceAddIntegrationToWorkspaceAddUsersToWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -238,7 +238,7 @@ func (v *AddUsersToWorkspaceAddUsersToWorkspaceAddUsersToWorkspacePayloadWorkspa
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal AddUsersToWorkspaceAddUsersToWorkspaceAddUsersToWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal AddUsersToWorkspaceAddUsersToWorkspaceAddUsersToWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -379,7 +379,7 @@ func (v *CreateWorkspaceCreateWorkspaceCreateWorkspacePayloadWorkspace) __premar
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal CreateWorkspaceCreateWorkspaceCreateWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal CreateWorkspaceCreateWorkspaceCreateWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -535,7 +535,7 @@ func (v *FindByUserFindByUserWorkspace) __premarshalJSON() (*__premarshalFindByU
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal FindByUserFindByUserWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal FindByUserFindByUserWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -790,7 +790,7 @@ func (v *FragmentWorkspace) UnmarshalJSON(b []byte) error {
 					src, dst)
 				if err != nil {
 					return fmt.Errorf(
-						"Unable to unmarshal FragmentWorkspace.Members: %w", err)
+						"unable to unmarshal FragmentWorkspace.Members: %w", err)
 				}
 			}
 		}
@@ -836,7 +836,7 @@ func (v *FragmentWorkspace) __premarshalJSON() (*__premarshalFragmentWorkspace, 
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal FragmentWorkspace.Members: %w", err)
+					"unable to marshal FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -874,17 +874,17 @@ func (v *FragmentWorkspaceMembersWorkspaceIntegrationMember) GetInvitedById() st
 // FragmentWorkspaceMembersWorkspaceMember includes the requested fields of the GraphQL interface WorkspaceMember.
 //
 // FragmentWorkspaceMembersWorkspaceMember is implemented by the following types:
-// FragmentWorkspaceMembersWorkspaceUserMember
 // FragmentWorkspaceMembersWorkspaceIntegrationMember
+// FragmentWorkspaceMembersWorkspaceUserMember
 type FragmentWorkspaceMembersWorkspaceMember interface {
 	implementsGraphQLInterfaceFragmentWorkspaceMembersWorkspaceMember()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
 	GetTypename() string
 }
 
-func (v *FragmentWorkspaceMembersWorkspaceUserMember) implementsGraphQLInterfaceFragmentWorkspaceMembersWorkspaceMember() {
-}
 func (v *FragmentWorkspaceMembersWorkspaceIntegrationMember) implementsGraphQLInterfaceFragmentWorkspaceMembersWorkspaceMember() {
+}
+func (v *FragmentWorkspaceMembersWorkspaceUserMember) implementsGraphQLInterfaceFragmentWorkspaceMembersWorkspaceMember() {
 }
 
 func __unmarshalFragmentWorkspaceMembersWorkspaceMember(b []byte, v *FragmentWorkspaceMembersWorkspaceMember) error {
@@ -901,11 +901,11 @@ func __unmarshalFragmentWorkspaceMembersWorkspaceMember(b []byte, v *FragmentWor
 	}
 
 	switch tn.TypeName {
-	case "WorkspaceUserMember":
-		*v = new(FragmentWorkspaceMembersWorkspaceUserMember)
-		return json.Unmarshal(b, *v)
 	case "WorkspaceIntegrationMember":
 		*v = new(FragmentWorkspaceMembersWorkspaceIntegrationMember)
+		return json.Unmarshal(b, *v)
+	case "WorkspaceUserMember":
+		*v = new(FragmentWorkspaceMembersWorkspaceUserMember)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -920,20 +920,20 @@ func __marshalFragmentWorkspaceMembersWorkspaceMember(v *FragmentWorkspaceMember
 
 	var typename string
 	switch v := (*v).(type) {
-	case *FragmentWorkspaceMembersWorkspaceUserMember:
-		typename = "WorkspaceUserMember"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*FragmentWorkspaceMembersWorkspaceUserMember
-		}{typename, v}
-		return json.Marshal(result)
 	case *FragmentWorkspaceMembersWorkspaceIntegrationMember:
 		typename = "WorkspaceIntegrationMember"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*FragmentWorkspaceMembersWorkspaceIntegrationMember
+		}{typename, v}
+		return json.Marshal(result)
+	case *FragmentWorkspaceMembersWorkspaceUserMember:
+		typename = "WorkspaceUserMember"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*FragmentWorkspaceMembersWorkspaceUserMember
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -1115,7 +1115,7 @@ func (v *RemoveIntegrationFromWorkspaceRemoveIntegrationFromWorkspaceRemoveMembe
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal RemoveIntegrationFromWorkspaceRemoveIntegrationFromWorkspaceRemoveMemberFromWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal RemoveIntegrationFromWorkspaceRemoveIntegrationFromWorkspaceRemoveMemberFromWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -1130,6 +1130,132 @@ type RemoveIntegrationFromWorkspaceResponse struct {
 // GetRemoveIntegrationFromWorkspace returns RemoveIntegrationFromWorkspaceResponse.RemoveIntegrationFromWorkspace, and is useful for accessing the field via an interface.
 func (v *RemoveIntegrationFromWorkspaceResponse) GetRemoveIntegrationFromWorkspace() RemoveIntegrationFromWorkspaceRemoveIntegrationFromWorkspaceRemoveMemberFromWorkspacePayload {
 	return v.RemoveIntegrationFromWorkspace
+}
+
+type RemoveMultipleUsersFromWorkspaceInput struct {
+	WorkspaceId string   `json:"workspaceId"`
+	UserIds     []string `json:"userIds"`
+}
+
+// GetWorkspaceId returns RemoveMultipleUsersFromWorkspaceInput.WorkspaceId, and is useful for accessing the field via an interface.
+func (v *RemoveMultipleUsersFromWorkspaceInput) GetWorkspaceId() string { return v.WorkspaceId }
+
+// GetUserIds returns RemoveMultipleUsersFromWorkspaceInput.UserIds, and is useful for accessing the field via an interface.
+func (v *RemoveMultipleUsersFromWorkspaceInput) GetUserIds() []string { return v.UserIds }
+
+// RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayload includes the requested fields of the GraphQL type RemoveMultipleMembersFromWorkspacePayload.
+type RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayload struct {
+	Workspace RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace `json:"workspace"`
+}
+
+// GetWorkspace returns RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayload.Workspace, and is useful for accessing the field via an interface.
+func (v *RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayload) GetWorkspace() RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace {
+	return v.Workspace
+}
+
+// RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace includes the requested fields of the GraphQL type Workspace.
+type RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace struct {
+	FragmentWorkspace `json:"-"`
+}
+
+// GetId returns RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace.Id, and is useful for accessing the field via an interface.
+func (v *RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace) GetId() string {
+	return v.FragmentWorkspace.Id
+}
+
+// GetName returns RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace.Name, and is useful for accessing the field via an interface.
+func (v *RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace) GetName() string {
+	return v.FragmentWorkspace.Name
+}
+
+// GetPersonal returns RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace.Personal, and is useful for accessing the field via an interface.
+func (v *RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace) GetPersonal() bool {
+	return v.FragmentWorkspace.Personal
+}
+
+// GetMembers returns RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace.Members, and is useful for accessing the field via an interface.
+func (v *RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace) GetMembers() []FragmentWorkspaceMembersWorkspaceMember {
+	return v.FragmentWorkspace.Members
+}
+
+func (v *RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.FragmentWorkspace)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalRemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	Personal bool `json:"personal"`
+
+	Members []json.RawMessage `json:"members"`
+}
+
+func (v *RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace) __premarshalJSON() (*__premarshalRemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace, error) {
+	var retval __premarshalRemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace
+
+	retval.Id = v.FragmentWorkspace.Id
+	retval.Name = v.FragmentWorkspace.Name
+	retval.Personal = v.FragmentWorkspace.Personal
+	{
+
+		dst := &retval.Members
+		src := v.FragmentWorkspace.Members
+		*dst = make(
+			[]json.RawMessage,
+			len(src))
+		for i, src := range src {
+			dst := &(*dst)[i]
+			var err error
+			*dst, err = __marshalFragmentWorkspaceMembersWorkspaceMember(
+				&src)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"unable to marshal RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+			}
+		}
+	}
+	return &retval, nil
+}
+
+// RemoveMultipleUsersFromWorkspaceResponse is returned by RemoveMultipleUsersFromWorkspace on success.
+type RemoveMultipleUsersFromWorkspaceResponse struct {
+	RemoveMultipleUsersFromWorkspace RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayload `json:"removeMultipleUsersFromWorkspace"`
+}
+
+// GetRemoveMultipleUsersFromWorkspace returns RemoveMultipleUsersFromWorkspaceResponse.RemoveMultipleUsersFromWorkspace, and is useful for accessing the field via an interface.
+func (v *RemoveMultipleUsersFromWorkspaceResponse) GetRemoveMultipleUsersFromWorkspace() RemoveMultipleUsersFromWorkspaceRemoveMultipleUsersFromWorkspaceRemoveMultipleMembersFromWorkspacePayload {
+	return v.RemoveMultipleUsersFromWorkspace
 }
 
 type RemoveMyAuthInput struct {
@@ -1358,7 +1484,7 @@ func (v *RemoveUserFromWorkspaceRemoveUserFromWorkspaceRemoveMemberFromWorkspace
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal RemoveUserFromWorkspaceRemoveUserFromWorkspaceRemoveMemberFromWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal RemoveUserFromWorkspaceRemoveUserFromWorkspaceRemoveMemberFromWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -1886,7 +2012,7 @@ func (v *UpdateIntegrationOfWorkspaceUpdateIntegrationOfWorkspaceUpdateMemberOfW
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal UpdateIntegrationOfWorkspaceUpdateIntegrationOfWorkspaceUpdateMemberOfWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal UpdateIntegrationOfWorkspaceUpdateIntegrationOfWorkspaceUpdateMemberOfWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -2149,7 +2275,7 @@ func (v *UpdateUserOfWorkspaceUpdateUserOfWorkspaceUpdateMemberOfWorkspacePayloa
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal UpdateUserOfWorkspaceUpdateUserOfWorkspaceUpdateMemberOfWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal UpdateUserOfWorkspaceUpdateUserOfWorkspaceUpdateMemberOfWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -2275,7 +2401,7 @@ func (v *UpdateWorkspaceUpdateWorkspaceUpdateWorkspacePayloadWorkspace) __premar
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal UpdateWorkspaceUpdateWorkspaceUpdateWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal UpdateWorkspaceUpdateWorkspaceUpdateWorkspacePayloadWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -2285,16 +2411,16 @@ func (v *UpdateWorkspaceUpdateWorkspaceUpdateWorkspacePayloadWorkspace) __premar
 // UserByIDsNodesNode includes the requested fields of the GraphQL interface Node.
 //
 // UserByIDsNodesNode is implemented by the following types:
-// UserByIDsNodesWorkspace
 // UserByIDsNodesUser
+// UserByIDsNodesWorkspace
 type UserByIDsNodesNode interface {
 	implementsGraphQLInterfaceUserByIDsNodesNode()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
 	GetTypename() string
 }
 
-func (v *UserByIDsNodesWorkspace) implementsGraphQLInterfaceUserByIDsNodesNode() {}
 func (v *UserByIDsNodesUser) implementsGraphQLInterfaceUserByIDsNodesNode()      {}
+func (v *UserByIDsNodesWorkspace) implementsGraphQLInterfaceUserByIDsNodesNode() {}
 
 func __unmarshalUserByIDsNodesNode(b []byte, v *UserByIDsNodesNode) error {
 	if string(b) == "null" {
@@ -2310,11 +2436,11 @@ func __unmarshalUserByIDsNodesNode(b []byte, v *UserByIDsNodesNode) error {
 	}
 
 	switch tn.TypeName {
-	case "Workspace":
-		*v = new(UserByIDsNodesWorkspace)
-		return json.Unmarshal(b, *v)
 	case "User":
 		*v = new(UserByIDsNodesUser)
+		return json.Unmarshal(b, *v)
+	case "Workspace":
+		*v = new(UserByIDsNodesWorkspace)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -2329,20 +2455,20 @@ func __marshalUserByIDsNodesNode(v *UserByIDsNodesNode) ([]byte, error) {
 
 	var typename string
 	switch v := (*v).(type) {
-	case *UserByIDsNodesWorkspace:
-		typename = "Workspace"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*UserByIDsNodesWorkspace
-		}{typename, v}
-		return json.Marshal(result)
 	case *UserByIDsNodesUser:
 		typename = "User"
 
 		result := struct {
 			TypeName string `json:"__typename"`
 			*UserByIDsNodesUser
+		}{typename, v}
+		return json.Marshal(result)
+	case *UserByIDsNodesWorkspace:
+		typename = "Workspace"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*UserByIDsNodesWorkspace
 		}{typename, v}
 		return json.Marshal(result)
 	case nil:
@@ -2436,7 +2562,7 @@ func (v *UserByIDsResponse) UnmarshalJSON(b []byte) error {
 					src, dst)
 				if err != nil {
 					return fmt.Errorf(
-						"Unable to unmarshal UserByIDsResponse.Nodes: %w", err)
+						"unable to unmarshal UserByIDsResponse.Nodes: %w", err)
 				}
 			}
 		}
@@ -2473,7 +2599,7 @@ func (v *UserByIDsResponse) __premarshalJSON() (*__premarshalUserByIDsResponse, 
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal UserByIDsResponse.Nodes: %w", err)
+					"unable to marshal UserByIDsResponse.Nodes: %w", err)
 			}
 		}
 	}
@@ -2596,16 +2722,16 @@ func (v *VerifyUserVerifyUserUserPayloadUser) __premarshalJSON() (*__premarshalV
 // WorkspaceByIDsNodesNode includes the requested fields of the GraphQL interface Node.
 //
 // WorkspaceByIDsNodesNode is implemented by the following types:
-// WorkspaceByIDsNodesWorkspace
 // WorkspaceByIDsNodesUser
+// WorkspaceByIDsNodesWorkspace
 type WorkspaceByIDsNodesNode interface {
 	implementsGraphQLInterfaceWorkspaceByIDsNodesNode()
 	// GetTypename returns the receiver's concrete GraphQL type-name (see interface doc for possible values).
 	GetTypename() string
 }
 
-func (v *WorkspaceByIDsNodesWorkspace) implementsGraphQLInterfaceWorkspaceByIDsNodesNode() {}
 func (v *WorkspaceByIDsNodesUser) implementsGraphQLInterfaceWorkspaceByIDsNodesNode()      {}
+func (v *WorkspaceByIDsNodesWorkspace) implementsGraphQLInterfaceWorkspaceByIDsNodesNode() {}
 
 func __unmarshalWorkspaceByIDsNodesNode(b []byte, v *WorkspaceByIDsNodesNode) error {
 	if string(b) == "null" {
@@ -2621,11 +2747,11 @@ func __unmarshalWorkspaceByIDsNodesNode(b []byte, v *WorkspaceByIDsNodesNode) er
 	}
 
 	switch tn.TypeName {
-	case "Workspace":
-		*v = new(WorkspaceByIDsNodesWorkspace)
-		return json.Unmarshal(b, *v)
 	case "User":
 		*v = new(WorkspaceByIDsNodesUser)
+		return json.Unmarshal(b, *v)
+	case "Workspace":
+		*v = new(WorkspaceByIDsNodesWorkspace)
 		return json.Unmarshal(b, *v)
 	case "":
 		return fmt.Errorf(
@@ -2640,6 +2766,14 @@ func __marshalWorkspaceByIDsNodesNode(v *WorkspaceByIDsNodesNode) ([]byte, error
 
 	var typename string
 	switch v := (*v).(type) {
+	case *WorkspaceByIDsNodesUser:
+		typename = "User"
+
+		result := struct {
+			TypeName string `json:"__typename"`
+			*WorkspaceByIDsNodesUser
+		}{typename, v}
+		return json.Marshal(result)
 	case *WorkspaceByIDsNodesWorkspace:
 		typename = "Workspace"
 
@@ -2651,14 +2785,6 @@ func __marshalWorkspaceByIDsNodesNode(v *WorkspaceByIDsNodesNode) ([]byte, error
 			TypeName string `json:"__typename"`
 			*__premarshalWorkspaceByIDsNodesWorkspace
 		}{typename, premarshaled}
-		return json.Marshal(result)
-	case *WorkspaceByIDsNodesUser:
-		typename = "User"
-
-		result := struct {
-			TypeName string `json:"__typename"`
-			*WorkspaceByIDsNodesUser
-		}{typename, v}
 		return json.Marshal(result)
 	case nil:
 		return []byte("null"), nil
@@ -2765,7 +2891,7 @@ func (v *WorkspaceByIDsNodesWorkspace) __premarshalJSON() (*__premarshalWorkspac
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal WorkspaceByIDsNodesWorkspace.FragmentWorkspace.Members: %w", err)
+					"unable to marshal WorkspaceByIDsNodesWorkspace.FragmentWorkspace.Members: %w", err)
 			}
 		}
 	}
@@ -2811,7 +2937,7 @@ func (v *WorkspaceByIDsResponse) UnmarshalJSON(b []byte) error {
 					src, dst)
 				if err != nil {
 					return fmt.Errorf(
-						"Unable to unmarshal WorkspaceByIDsResponse.Nodes: %w", err)
+						"unable to unmarshal WorkspaceByIDsResponse.Nodes: %w", err)
 				}
 			}
 		}
@@ -2848,7 +2974,7 @@ func (v *WorkspaceByIDsResponse) __premarshalJSON() (*__premarshalWorkspaceByIDs
 				&src)
 			if err != nil {
 				return nil, fmt.Errorf(
-					"Unable to marshal WorkspaceByIDsResponse.Nodes: %w", err)
+					"unable to marshal WorkspaceByIDsResponse.Nodes: %w", err)
 			}
 		}
 	}
@@ -2934,6 +3060,16 @@ type __RemoveIntegrationFromWorkspaceInput struct {
 
 // GetInput returns __RemoveIntegrationFromWorkspaceInput.Input, and is useful for accessing the field via an interface.
 func (v *__RemoveIntegrationFromWorkspaceInput) GetInput() RemoveIntegrationFromWorkspaceInput {
+	return v.Input
+}
+
+// __RemoveMultipleUsersFromWorkspaceInput is used internally by genqlient
+type __RemoveMultipleUsersFromWorkspaceInput struct {
+	Input RemoveMultipleUsersFromWorkspaceInput `json:"input"`
+}
+
+// GetInput returns __RemoveMultipleUsersFromWorkspaceInput.Input, and is useful for accessing the field via an interface.
+func (v *__RemoveMultipleUsersFromWorkspaceInput) GetInput() RemoveMultipleUsersFromWorkspaceInput {
 	return v.Input
 }
 
@@ -3043,14 +3179,8 @@ type __WorkspaceByIDsInput struct {
 // GetId returns __WorkspaceByIDsInput.Id, and is useful for accessing the field via an interface.
 func (v *__WorkspaceByIDsInput) GetId() []string { return v.Id }
 
-func AddIntegrationToWorkspace(
-	ctx context.Context,
-	client graphql.Client,
-	input AddIntegrationToWorkspaceInput,
-) (*AddIntegrationToWorkspaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "AddIntegrationToWorkspace",
-		Query: `
+// The query or mutation executed by AddIntegrationToWorkspace.
+const AddIntegrationToWorkspace_Operation = `
 mutation AddIntegrationToWorkspace ($input: AddIntegrationToWorkspaceInput!) {
 	addIntegrationToWorkspace(input: $input) {
 		workspace {
@@ -3076,7 +3206,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func AddIntegrationToWorkspace(
+	ctx context.Context,
+	client graphql.Client,
+	input AddIntegrationToWorkspaceInput,
+) (*AddIntegrationToWorkspaceResponse, error) {
+	req := &graphql.Request{
+		OpName: "AddIntegrationToWorkspace",
+		Query:  AddIntegrationToWorkspace_Operation,
 		Variables: &__AddIntegrationToWorkspaceInput{
 			Input: input,
 		},
@@ -3095,14 +3234,8 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
-func AddUsersToWorkspace(
-	ctx context.Context,
-	client graphql.Client,
-	input AddUsersToWorkspaceInput,
-) (*AddUsersToWorkspaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "AddUsersToWorkspace",
-		Query: `
+// The query or mutation executed by AddUsersToWorkspace.
+const AddUsersToWorkspace_Operation = `
 mutation AddUsersToWorkspace ($input: AddUsersToWorkspaceInput!) {
 	addUsersToWorkspace(input: $input) {
 		workspace {
@@ -3128,7 +3261,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func AddUsersToWorkspace(
+	ctx context.Context,
+	client graphql.Client,
+	input AddUsersToWorkspaceInput,
+) (*AddUsersToWorkspaceResponse, error) {
+	req := &graphql.Request{
+		OpName: "AddUsersToWorkspace",
+		Query:  AddUsersToWorkspace_Operation,
 		Variables: &__AddUsersToWorkspaceInput{
 			Input: input,
 		},
@@ -3147,6 +3289,13 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
+// The query or mutation executed by CreateVerification.
+const CreateVerification_Operation = `
+mutation CreateVerification ($input: CreateVerificationInput!) {
+	createVerification(input: $input)
+}
+`
+
 func CreateVerification(
 	ctx context.Context,
 	client graphql.Client,
@@ -3154,11 +3303,7 @@ func CreateVerification(
 ) (*CreateVerificationResponse, error) {
 	req := &graphql.Request{
 		OpName: "CreateVerification",
-		Query: `
-mutation CreateVerification ($input: CreateVerificationInput!) {
-	createVerification(input: $input)
-}
-`,
+		Query:  CreateVerification_Operation,
 		Variables: &__CreateVerificationInput{
 			Input: input,
 		},
@@ -3177,14 +3322,8 @@ mutation CreateVerification ($input: CreateVerificationInput!) {
 	return &data, err
 }
 
-func CreateWorkspace(
-	ctx context.Context,
-	client graphql.Client,
-	input CreateWorkspaceInput,
-) (*CreateWorkspaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "CreateWorkspace",
-		Query: `
+// The query or mutation executed by CreateWorkspace.
+const CreateWorkspace_Operation = `
 mutation CreateWorkspace ($input: CreateWorkspaceInput!) {
 	createWorkspace(input: $input) {
 		workspace {
@@ -3210,7 +3349,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func CreateWorkspace(
+	ctx context.Context,
+	client graphql.Client,
+	input CreateWorkspaceInput,
+) (*CreateWorkspaceResponse, error) {
+	req := &graphql.Request{
+		OpName: "CreateWorkspace",
+		Query:  CreateWorkspace_Operation,
 		Variables: &__CreateWorkspaceInput{
 			Input: input,
 		},
@@ -3229,6 +3377,15 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
+// The query or mutation executed by DeleteMe.
+const DeleteMe_Operation = `
+mutation DeleteMe ($input: DeleteMeInput!) {
+	deleteMe(input: $input) {
+		userId
+	}
+}
+`
+
 func DeleteMe(
 	ctx context.Context,
 	client graphql.Client,
@@ -3236,13 +3393,7 @@ func DeleteMe(
 ) (*DeleteMeResponse, error) {
 	req := &graphql.Request{
 		OpName: "DeleteMe",
-		Query: `
-mutation DeleteMe ($input: DeleteMeInput!) {
-	deleteMe(input: $input) {
-		userId
-	}
-}
-`,
+		Query:  DeleteMe_Operation,
 		Variables: &__DeleteMeInput{
 			Input: input,
 		},
@@ -3261,6 +3412,15 @@ mutation DeleteMe ($input: DeleteMeInput!) {
 	return &data, err
 }
 
+// The query or mutation executed by DeleteWorkspace.
+const DeleteWorkspace_Operation = `
+mutation DeleteWorkspace ($input: DeleteWorkspaceInput!) {
+	deleteWorkspace(input: $input) {
+		workspaceId
+	}
+}
+`
+
 func DeleteWorkspace(
 	ctx context.Context,
 	client graphql.Client,
@@ -3268,13 +3428,7 @@ func DeleteWorkspace(
 ) (*DeleteWorkspaceResponse, error) {
 	req := &graphql.Request{
 		OpName: "DeleteWorkspace",
-		Query: `
-mutation DeleteWorkspace ($input: DeleteWorkspaceInput!) {
-	deleteWorkspace(input: $input) {
-		workspaceId
-	}
-}
-`,
+		Query:  DeleteWorkspace_Operation,
 		Variables: &__DeleteWorkspaceInput{
 			Input: input,
 		},
@@ -3293,14 +3447,8 @@ mutation DeleteWorkspace ($input: DeleteWorkspaceInput!) {
 	return &data, err
 }
 
-func FindByUser(
-	ctx context.Context,
-	client graphql.Client,
-	userId string,
-) (*FindByUserResponse, error) {
-	req := &graphql.Request{
-		OpName: "FindByUser",
-		Query: `
+// The query or mutation executed by FindByUser.
+const FindByUser_Operation = `
 query FindByUser ($userId: ID!) {
 	findByUser(userId: $userId) {
 		... FragmentWorkspace
@@ -3324,7 +3472,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func FindByUser(
+	ctx context.Context,
+	client graphql.Client,
+	userId string,
+) (*FindByUserResponse, error) {
+	req := &graphql.Request{
+		OpName: "FindByUser",
+		Query:  FindByUser_Operation,
 		Variables: &__FindByUserInput{
 			UserId: userId,
 		},
@@ -3343,14 +3500,8 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
-func FindOrCreate(
-	ctx context.Context,
-	client graphql.Client,
-	input FindOrCreateInput,
-) (*FindOrCreateResponse, error) {
-	req := &graphql.Request{
-		OpName: "FindOrCreate",
-		Query: `
+// The query or mutation executed by FindOrCreate.
+const FindOrCreate_Operation = `
 mutation FindOrCreate ($input: FindOrCreateInput!) {
 	findOrCreate(input: $input) {
 		user {
@@ -3367,7 +3518,16 @@ fragment FragmentUser on User {
 	workspace
 	auths
 }
-`,
+`
+
+func FindOrCreate(
+	ctx context.Context,
+	client graphql.Client,
+	input FindOrCreateInput,
+) (*FindOrCreateResponse, error) {
+	req := &graphql.Request{
+		OpName: "FindOrCreate",
+		Query:  FindOrCreate_Operation,
 		Variables: &__FindOrCreateInput{
 			Input: input,
 		},
@@ -3386,19 +3546,22 @@ fragment FragmentUser on User {
 	return &data, err
 }
 
+// The query or mutation executed by Me.
+const Me_Operation = `
+query Me {
+	me {
+		id
+	}
+}
+`
+
 func Me(
 	ctx context.Context,
 	client graphql.Client,
 ) (*MeResponse, error) {
 	req := &graphql.Request{
 		OpName: "Me",
-		Query: `
-query Me {
-	me {
-		id
-	}
-}
-`,
+		Query:  Me_Operation,
 	}
 	var err error
 
@@ -3414,6 +3577,13 @@ query Me {
 	return &data, err
 }
 
+// The query or mutation executed by PasswordReset.
+const PasswordReset_Operation = `
+mutation PasswordReset ($input: PasswordResetInput!) {
+	passwordReset(input: $input)
+}
+`
+
 func PasswordReset(
 	ctx context.Context,
 	client graphql.Client,
@@ -3421,11 +3591,7 @@ func PasswordReset(
 ) (*PasswordResetResponse, error) {
 	req := &graphql.Request{
 		OpName: "PasswordReset",
-		Query: `
-mutation PasswordReset ($input: PasswordResetInput!) {
-	passwordReset(input: $input)
-}
-`,
+		Query:  PasswordReset_Operation,
 		Variables: &__PasswordResetInput{
 			Input: input,
 		},
@@ -3444,14 +3610,8 @@ mutation PasswordReset ($input: PasswordResetInput!) {
 	return &data, err
 }
 
-func RemoveIntegrationFromWorkspace(
-	ctx context.Context,
-	client graphql.Client,
-	input RemoveIntegrationFromWorkspaceInput,
-) (*RemoveIntegrationFromWorkspaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "RemoveIntegrationFromWorkspace",
-		Query: `
+// The query or mutation executed by RemoveIntegrationFromWorkspace.
+const RemoveIntegrationFromWorkspace_Operation = `
 mutation RemoveIntegrationFromWorkspace ($input: RemoveIntegrationFromWorkspaceInput!) {
 	removeIntegrationFromWorkspace(input: $input) {
 		workspace {
@@ -3477,7 +3637,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func RemoveIntegrationFromWorkspace(
+	ctx context.Context,
+	client graphql.Client,
+	input RemoveIntegrationFromWorkspaceInput,
+) (*RemoveIntegrationFromWorkspaceResponse, error) {
+	req := &graphql.Request{
+		OpName: "RemoveIntegrationFromWorkspace",
+		Query:  RemoveIntegrationFromWorkspace_Operation,
 		Variables: &__RemoveIntegrationFromWorkspaceInput{
 			Input: input,
 		},
@@ -3496,14 +3665,63 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
-func RemoveMyAuth(
+// The query or mutation executed by RemoveMultipleUsersFromWorkspace.
+const RemoveMultipleUsersFromWorkspace_Operation = `
+mutation RemoveMultipleUsersFromWorkspace ($input: RemoveMultipleUsersFromWorkspaceInput!) {
+	removeMultipleUsersFromWorkspace(input: $input) {
+		workspace {
+			... FragmentWorkspace
+		}
+	}
+}
+fragment FragmentWorkspace on Workspace {
+	id
+	name
+	personal
+	members {
+		__typename
+		... on WorkspaceUserMember {
+			userId
+			role
+		}
+		... on WorkspaceIntegrationMember {
+			integrationId
+			role
+			active
+			invitedById
+		}
+	}
+}
+`
+
+func RemoveMultipleUsersFromWorkspace(
 	ctx context.Context,
 	client graphql.Client,
-	input RemoveMyAuthInput,
-) (*RemoveMyAuthResponse, error) {
+	input RemoveMultipleUsersFromWorkspaceInput,
+) (*RemoveMultipleUsersFromWorkspaceResponse, error) {
 	req := &graphql.Request{
-		OpName: "RemoveMyAuth",
-		Query: `
+		OpName: "RemoveMultipleUsersFromWorkspace",
+		Query:  RemoveMultipleUsersFromWorkspace_Operation,
+		Variables: &__RemoveMultipleUsersFromWorkspaceInput{
+			Input: input,
+		},
+	}
+	var err error
+
+	var data RemoveMultipleUsersFromWorkspaceResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by RemoveMyAuth.
+const RemoveMyAuth_Operation = `
 mutation RemoveMyAuth ($input: RemoveMyAuthInput!) {
 	removeMyAuth(input: $input) {
 		me {
@@ -3520,7 +3738,16 @@ fragment FragmentMe on Me {
 	myWorkspaceId
 	auths
 }
-`,
+`
+
+func RemoveMyAuth(
+	ctx context.Context,
+	client graphql.Client,
+	input RemoveMyAuthInput,
+) (*RemoveMyAuthResponse, error) {
+	req := &graphql.Request{
+		OpName: "RemoveMyAuth",
+		Query:  RemoveMyAuth_Operation,
 		Variables: &__RemoveMyAuthInput{
 			Input: input,
 		},
@@ -3539,14 +3766,8 @@ fragment FragmentMe on Me {
 	return &data, err
 }
 
-func RemoveUserFromWorkspace(
-	ctx context.Context,
-	client graphql.Client,
-	input RemoveUserFromWorkspaceInput,
-) (*RemoveUserFromWorkspaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "RemoveUserFromWorkspace",
-		Query: `
+// The query or mutation executed by RemoveUserFromWorkspace.
+const RemoveUserFromWorkspace_Operation = `
 mutation RemoveUserFromWorkspace ($input: RemoveUserFromWorkspaceInput!) {
 	removeUserFromWorkspace(input: $input) {
 		workspace {
@@ -3572,7 +3793,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func RemoveUserFromWorkspace(
+	ctx context.Context,
+	client graphql.Client,
+	input RemoveUserFromWorkspaceInput,
+) (*RemoveUserFromWorkspaceResponse, error) {
+	req := &graphql.Request{
+		OpName: "RemoveUserFromWorkspace",
+		Query:  RemoveUserFromWorkspace_Operation,
 		Variables: &__RemoveUserFromWorkspaceInput{
 			Input: input,
 		},
@@ -3591,14 +3821,8 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
-func SearchUser(
-	ctx context.Context,
-	client graphql.Client,
-	nameOrEmail string,
-) (*SearchUserResponse, error) {
-	req := &graphql.Request{
-		OpName: "SearchUser",
-		Query: `
+// The query or mutation executed by SearchUser.
+const SearchUser_Operation = `
 query SearchUser ($nameOrEmail: String!) {
 	searchUser(nameOrEmail: $nameOrEmail) {
 		... FragmentUser
@@ -3613,7 +3837,16 @@ fragment FragmentUser on User {
 	workspace
 	auths
 }
-`,
+`
+
+func SearchUser(
+	ctx context.Context,
+	client graphql.Client,
+	nameOrEmail string,
+) (*SearchUserResponse, error) {
+	req := &graphql.Request{
+		OpName: "SearchUser",
+		Query:  SearchUser_Operation,
 		Variables: &__SearchUserInput{
 			NameOrEmail: nameOrEmail,
 		},
@@ -3632,14 +3865,8 @@ fragment FragmentUser on User {
 	return &data, err
 }
 
-func SignUp(
-	ctx context.Context,
-	client graphql.Client,
-	input SignUpInput,
-) (*SignUpResponse, error) {
-	req := &graphql.Request{
-		OpName: "SignUp",
-		Query: `
+// The query or mutation executed by SignUp.
+const SignUp_Operation = `
 mutation SignUp ($input: SignUpInput!) {
 	signUp(input: $input) {
 		user {
@@ -3656,7 +3883,16 @@ fragment FragmentUser on User {
 	workspace
 	auths
 }
-`,
+`
+
+func SignUp(
+	ctx context.Context,
+	client graphql.Client,
+	input SignUpInput,
+) (*SignUpResponse, error) {
+	req := &graphql.Request{
+		OpName: "SignUp",
+		Query:  SignUp_Operation,
 		Variables: &__SignUpInput{
 			Input: input,
 		},
@@ -3675,14 +3911,8 @@ fragment FragmentUser on User {
 	return &data, err
 }
 
-func SignupOIDC(
-	ctx context.Context,
-	client graphql.Client,
-	input SignupOIDCInput,
-) (*SignupOIDCResponse, error) {
-	req := &graphql.Request{
-		OpName: "SignupOIDC",
-		Query: `
+// The query or mutation executed by SignupOIDC.
+const SignupOIDC_Operation = `
 mutation SignupOIDC ($input: SignupOIDCInput!) {
 	signUpOIDC(input: $input) {
 		user {
@@ -3699,7 +3929,16 @@ fragment FragmentUser on User {
 	workspace
 	auths
 }
-`,
+`
+
+func SignupOIDC(
+	ctx context.Context,
+	client graphql.Client,
+	input SignupOIDCInput,
+) (*SignupOIDCResponse, error) {
+	req := &graphql.Request{
+		OpName: "SignupOIDC",
+		Query:  SignupOIDC_Operation,
 		Variables: &__SignupOIDCInput{
 			Input: input,
 		},
@@ -3718,6 +3957,13 @@ fragment FragmentUser on User {
 	return &data, err
 }
 
+// The query or mutation executed by StartPasswordReset.
+const StartPasswordReset_Operation = `
+mutation StartPasswordReset ($input: StartPasswordResetInput!) {
+	startPasswordReset(input: $input)
+}
+`
+
 func StartPasswordReset(
 	ctx context.Context,
 	client graphql.Client,
@@ -3725,11 +3971,7 @@ func StartPasswordReset(
 ) (*StartPasswordResetResponse, error) {
 	req := &graphql.Request{
 		OpName: "StartPasswordReset",
-		Query: `
-mutation StartPasswordReset ($input: StartPasswordResetInput!) {
-	startPasswordReset(input: $input)
-}
-`,
+		Query:  StartPasswordReset_Operation,
 		Variables: &__StartPasswordResetInput{
 			Input: input,
 		},
@@ -3748,14 +3990,8 @@ mutation StartPasswordReset ($input: StartPasswordResetInput!) {
 	return &data, err
 }
 
-func UpdateIntegrationOfWorkspace(
-	ctx context.Context,
-	client graphql.Client,
-	input UpdateIntegrationOfWorkspaceInput,
-) (*UpdateIntegrationOfWorkspaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "UpdateIntegrationOfWorkspace",
-		Query: `
+// The query or mutation executed by UpdateIntegrationOfWorkspace.
+const UpdateIntegrationOfWorkspace_Operation = `
 mutation UpdateIntegrationOfWorkspace ($input: UpdateIntegrationOfWorkspaceInput!) {
 	updateIntegrationOfWorkspace(input: $input) {
 		workspace {
@@ -3781,7 +4017,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func UpdateIntegrationOfWorkspace(
+	ctx context.Context,
+	client graphql.Client,
+	input UpdateIntegrationOfWorkspaceInput,
+) (*UpdateIntegrationOfWorkspaceResponse, error) {
+	req := &graphql.Request{
+		OpName: "UpdateIntegrationOfWorkspace",
+		Query:  UpdateIntegrationOfWorkspace_Operation,
 		Variables: &__UpdateIntegrationOfWorkspaceInput{
 			Input: input,
 		},
@@ -3800,14 +4045,8 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
-func UpdateMe(
-	ctx context.Context,
-	client graphql.Client,
-	input UpdateMeInput,
-) (*UpdateMeResponse, error) {
-	req := &graphql.Request{
-		OpName: "UpdateMe",
-		Query: `
+// The query or mutation executed by UpdateMe.
+const UpdateMe_Operation = `
 mutation UpdateMe ($input: UpdateMeInput!) {
 	updateMe(input: $input) {
 		me {
@@ -3824,7 +4063,16 @@ fragment FragmentMe on Me {
 	myWorkspaceId
 	auths
 }
-`,
+`
+
+func UpdateMe(
+	ctx context.Context,
+	client graphql.Client,
+	input UpdateMeInput,
+) (*UpdateMeResponse, error) {
+	req := &graphql.Request{
+		OpName: "UpdateMe",
+		Query:  UpdateMe_Operation,
 		Variables: &__UpdateMeInput{
 			Input: input,
 		},
@@ -3843,14 +4091,8 @@ fragment FragmentMe on Me {
 	return &data, err
 }
 
-func UpdateUserOfWorkspace(
-	ctx context.Context,
-	client graphql.Client,
-	input UpdateUserOfWorkspaceInput,
-) (*UpdateUserOfWorkspaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "UpdateUserOfWorkspace",
-		Query: `
+// The query or mutation executed by UpdateUserOfWorkspace.
+const UpdateUserOfWorkspace_Operation = `
 mutation UpdateUserOfWorkspace ($input: UpdateUserOfWorkspaceInput!) {
 	updateUserOfWorkspace(input: $input) {
 		workspace {
@@ -3876,7 +4118,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func UpdateUserOfWorkspace(
+	ctx context.Context,
+	client graphql.Client,
+	input UpdateUserOfWorkspaceInput,
+) (*UpdateUserOfWorkspaceResponse, error) {
+	req := &graphql.Request{
+		OpName: "UpdateUserOfWorkspace",
+		Query:  UpdateUserOfWorkspace_Operation,
 		Variables: &__UpdateUserOfWorkspaceInput{
 			Input: input,
 		},
@@ -3895,14 +4146,8 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
-func UpdateWorkspace(
-	ctx context.Context,
-	client graphql.Client,
-	input UpdateWorkspaceInput,
-) (*UpdateWorkspaceResponse, error) {
-	req := &graphql.Request{
-		OpName: "UpdateWorkspace",
-		Query: `
+// The query or mutation executed by UpdateWorkspace.
+const UpdateWorkspace_Operation = `
 mutation UpdateWorkspace ($input: UpdateWorkspaceInput!) {
 	updateWorkspace(input: $input) {
 		workspace {
@@ -3928,7 +4173,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func UpdateWorkspace(
+	ctx context.Context,
+	client graphql.Client,
+	input UpdateWorkspaceInput,
+) (*UpdateWorkspaceResponse, error) {
+	req := &graphql.Request{
+		OpName: "UpdateWorkspace",
+		Query:  UpdateWorkspace_Operation,
 		Variables: &__UpdateWorkspaceInput{
 			Input: input,
 		},
@@ -3947,14 +4201,8 @@ fragment FragmentWorkspace on Workspace {
 	return &data, err
 }
 
-func UserByIDs(
-	ctx context.Context,
-	client graphql.Client,
-	id []string,
-) (*UserByIDsResponse, error) {
-	req := &graphql.Request{
-		OpName: "UserByIDs",
-		Query: `
+// The query or mutation executed by UserByIDs.
+const UserByIDs_Operation = `
 query UserByIDs ($id: [ID!]!) {
 	nodes(id: $id, type: USER) {
 		__typename
@@ -3969,7 +4217,16 @@ query UserByIDs ($id: [ID!]!) {
 		}
 	}
 }
-`,
+`
+
+func UserByIDs(
+	ctx context.Context,
+	client graphql.Client,
+	id []string,
+) (*UserByIDsResponse, error) {
+	req := &graphql.Request{
+		OpName: "UserByIDs",
+		Query:  UserByIDs_Operation,
 		Variables: &__UserByIDsInput{
 			Id: id,
 		},
@@ -3988,14 +4245,8 @@ query UserByIDs ($id: [ID!]!) {
 	return &data, err
 }
 
-func VerifyUser(
-	ctx context.Context,
-	client graphql.Client,
-	input VerifyUserInput,
-) (*VerifyUserResponse, error) {
-	req := &graphql.Request{
-		OpName: "VerifyUser",
-		Query: `
+// The query or mutation executed by VerifyUser.
+const VerifyUser_Operation = `
 mutation VerifyUser ($input: VerifyUserInput!) {
 	verifyUser(input: $input) {
 		user {
@@ -4012,7 +4263,16 @@ fragment FragmentUser on User {
 	workspace
 	auths
 }
-`,
+`
+
+func VerifyUser(
+	ctx context.Context,
+	client graphql.Client,
+	input VerifyUserInput,
+) (*VerifyUserResponse, error) {
+	req := &graphql.Request{
+		OpName: "VerifyUser",
+		Query:  VerifyUser_Operation,
 		Variables: &__VerifyUserInput{
 			Input: input,
 		},
@@ -4031,14 +4291,8 @@ fragment FragmentUser on User {
 	return &data, err
 }
 
-func WorkspaceByIDs(
-	ctx context.Context,
-	client graphql.Client,
-	id []string,
-) (*WorkspaceByIDsResponse, error) {
-	req := &graphql.Request{
-		OpName: "WorkspaceByIDs",
-		Query: `
+// The query or mutation executed by WorkspaceByIDs.
+const WorkspaceByIDs_Operation = `
 query WorkspaceByIDs ($id: [ID!]!) {
 	nodes(id: $id, type: WORKSPACE) {
 		__typename
@@ -4065,7 +4319,16 @@ fragment FragmentWorkspace on Workspace {
 		}
 	}
 }
-`,
+`
+
+func WorkspaceByIDs(
+	ctx context.Context,
+	client graphql.Client,
+	id []string,
+) (*WorkspaceByIDsResponse, error) {
+	req := &graphql.Request{
+		OpName: "WorkspaceByIDs",
+		Query:  WorkspaceByIDs_Operation,
 		Variables: &__WorkspaceByIDsInput{
 			Id: id,
 		},

--- a/account/accountusecase/accountproxy/operations.graphql
+++ b/account/accountusecase/accountproxy/operations.graphql
@@ -167,6 +167,12 @@ mutation RemoveUserFromWorkspace($input: RemoveUserFromWorkspaceInput!) {
     }
 }
 
+mutation RemoveMultipleUsersFromWorkspace($input: RemoveMultipleUsersFromWorkspaceInput!) {
+    removeMultipleUsersFromWorkspace(input: $input) {
+        workspace {...FragmentWorkspace}
+    }
+}
+
 mutation RemoveIntegrationFromWorkspace($input: RemoveIntegrationFromWorkspaceInput!) {
     removeIntegrationFromWorkspace(input: $input) {
         workspace{...FragmentWorkspace}

--- a/account/accountusecase/accountproxy/workspace.go
+++ b/account/accountusecase/accountproxy/workspace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/account/accountusecase"
 	"github.com/reearth/reearthx/account/accountusecase/accountinterfaces"
+	"github.com/samber/lo"
 )
 
 type Workspace struct {
@@ -101,6 +102,14 @@ func (w *Workspace) RemoveUserMember(ctx context.Context, id workspace.ID, userI
 		return nil, err
 	}
 	return ToWorkspace(res.RemoveUserFromWorkspace.Workspace.FragmentWorkspace)
+}
+
+func (w *Workspace) RemoveMultipleUserMembers(ctx context.Context, id workspace.ID, userIDs accountdomain.UserIDList, op *accountusecase.Operator) (*workspace.Workspace, error) {
+	res, err := RemoveMultipleUsersFromWorkspace(ctx, w.gql, RemoveMultipleUsersFromWorkspaceInput{WorkspaceId: id.String(), UserIds: lo.Map(userIDs, func(u accountdomain.UserID, _ int) string { return u.String() })})
+	if err != nil {
+		return nil, err
+	}
+	return ToWorkspace(res.RemoveMultipleUsersFromWorkspace.Workspace.FragmentWorkspace)
 }
 
 func (w *Workspace) RemoveIntegration(ctx context.Context, id workspace.ID, integrationID workspace.IntegrationID, op *accountusecase.Operator) (*workspace.Workspace, error) {

--- a/account/workspace.graphql
+++ b/account/workspace.graphql
@@ -63,6 +63,11 @@ input RemoveUserFromWorkspaceInput {
     userId: ID!
 }
 
+input RemoveMultipleUsersFromWorkspaceInput {
+    workspaceId: ID!
+    userIds: [ID!]!
+}
+
 input RemoveIntegrationFromWorkspaceInput {
     workspaceId: ID!
     integrationId: ID!
@@ -102,6 +107,10 @@ type RemoveMemberFromWorkspacePayload {
     workspace: Workspace!
 }
 
+type RemoveMultipleMembersFromWorkspacePayload {
+    workspace: Workspace!
+}
+
 type UpdateMemberOfWorkspacePayload {
     workspace: Workspace!
 }
@@ -121,6 +130,7 @@ extend type Mutation {
     addUsersToWorkspace(input: AddUsersToWorkspaceInput!): AddUsersToWorkspacePayload
     addIntegrationToWorkspace(input: AddIntegrationToWorkspaceInput!): AddUsersToWorkspacePayload
     removeUserFromWorkspace(input: RemoveUserFromWorkspaceInput!): RemoveMemberFromWorkspacePayload
+    removeMultipleUsersFromWorkspace(input: RemoveMultipleUsersFromWorkspaceInput!): RemoveMultipleMembersFromWorkspacePayload
     removeIntegrationFromWorkspace(input: RemoveIntegrationFromWorkspaceInput!): RemoveMemberFromWorkspacePayload
     updateUserOfWorkspace(input: UpdateUserOfWorkspaceInput!): UpdateMemberOfWorkspacePayload
     updateIntegrationOfWorkspace(input: UpdateIntegrationOfWorkspaceInput!): UpdateMemberOfWorkspacePayload


### PR DESCRIPTION
# Overview
This PR introduces a new mutation `removeMultipleUsersFromWorkspace` in the workspace schema. The mutation allows for the removal of multiple user-members from a workspace in a single operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced the ability to remove multiple user members from a workspace in a single operation.
  - Added a new GraphQL mutation for removing multiple users from a workspace.

- **Bug Fixes**
  - Enhanced error handling for scenarios involving user removal, including checks for empty user lists and attempts to remove workspace owners.

- **Tests**
  - Added comprehensive tests for the new functionality, covering various scenarios to ensure robust member management.

- **Documentation**
  - Updated GraphQL schema to include new input types and mutations related to user management in workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->