### PR TITLE
fix(mongox): duplicate sort key error in pagination function

### DIFF
--- a/mongox/pagination.go
+++ b/mongox/pagination.go
@@ -40,8 +40,13 @@ func (c *Collection) Paginate(ctx context.Context, rawFilter any, s *usecasex.So
 		sortOrder *= -1
 	}
 
+	sort := bson.D{{Key: sortKey, Value: sortOrder}}
+	if sortKey != idKey {
+		sort = append(sort, bson.E{Key: idKey, Value: sortOrder})
+	}
+
 	findOpts := options.Find().
-		SetSort(bson.D{{Key: sortKey, Value: sortOrder}, {Key: idKey, Value: sortOrder}}).
+		SetSort(sort).
 		SetLimit(limit(*p))
 
 	if p.Offset != nil {


### PR DESCRIPTION
# Overview
This PR resolves an issue in the Paginate function where duplicate sort keys ($sort) could be passed to MongoDB when the primary sortKey matched the idKey.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced sorting logic for pagination, allowing for improved flexibility in sorting options.
  
- **Bug Fixes**
	- Maintained consistent error handling and pagination checks to ensure robust functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->