### PR TITLE
fix(server): enable original key filter

### DIFF
--- a/mongox/pagination.go
+++ b/mongox/pagination.go
@@ -27,64 +27,7 @@ func (c *Collection) Paginate(ctx context.Context, rawFilter any, s *usecasex.So
 		filter = And(rawFilter, "", pFilter)
 	}
 
-	sortKey := idKey
-	sortOrder := 1
-	if s != nil && s.Key != "" {
-		sortKey = s.Key
-		if s.Reverted {
-			sortOrder = -1
-		}
-	}
-
-	if p.Cursor != nil && p.Cursor.Last != nil {
-		sortOrder *= -1
-	}
-
-	sort := bson.D{{Key: sortKey, Value: sortOrder}}
-	if sortKey != idKey {
-		sort = append(sort, bson.E{Key: idKey, Value: sortOrder})
-	}
-
-	findOpts := options.Find().
-		SetSort(sort).
-		SetLimit(limit(*p))
-
-	if p.Offset != nil {
-		findOpts.SetSkip(p.Offset.Offset)
-	}
-
-	cursor, err := c.collection.Find(ctx, filter, append([]*options.FindOptions{findOpts}, opts...)...)
-	if err != nil {
-		return nil, rerror.ErrInternalByWithContext(ctx, fmt.Errorf("failed to find: %w", err))
-	}
-	defer func() {
-		_ = cursor.Close(ctx)
-	}()
-
-	count, err := c.collection.CountDocuments(ctx, rawFilter)
-	if err != nil {
-		return nil, rerror.ErrInternalByWithContext(ctx, fmt.Errorf("failed to count: %w", err))
-	}
-
-	items, startCursor, endCursor, hasMore, err := consume(ctx, cursor, limit(*p))
-	if err != nil {
-		return nil, err
-	}
-
-	if p.Cursor != nil && p.Cursor.Last != nil {
-		reverse(items)
-		startCursor, endCursor = endCursor, startCursor
-	}
-
-	for _, item := range items {
-		if err := consumer.Consume(item); err != nil {
-			return nil, err
-		}
-	}
-
-	hasNextPage, hasPreviousPage := pageInfo(p, hasMore)
-
-	return usecasex.NewPageInfo(count, startCursor, endCursor, hasNextPage, hasPreviousPage), nil
+	return c.paginate(ctx, rawFilter, s, p, filter, consumer)
 }
 
 func (c *Collection) PaginateAggregation(ctx context.Context, pipeline []any, s *usecasex.Sort, p *usecasex.Pagination, consumer Consumer, opts ...*options.AggregateOptions) (*usecasex.PageInfo, error) {
@@ -326,4 +269,85 @@ func sortDirection(p usecasex.Pagination, s *usecasex.Sort) int {
 		return -1
 	}
 	return 1
+}
+
+func (c *Collection) PaginateProject(ctx context.Context, rawFilter any, s *usecasex.Sort, p *usecasex.Pagination, consumer Consumer, opts ...*options.FindOptions) (*usecasex.PageInfo, error) {
+	if p == nil || (p.Cursor == nil && p.Offset == nil) {
+		return nil, nil
+	}
+
+	pFilter, err := c.pageFilter(ctx, *p, s)
+	if err != nil {
+		return nil, rerror.ErrInternalByWithContext(ctx, err)
+	}
+
+	filter := rawFilter
+	if pFilter != nil {
+		filter = AddCondition(rawFilter, "", pFilter)
+	}
+
+	return c.paginate(ctx, rawFilter, s, p, filter, consumer)
+
+}
+
+func (c *Collection) paginate(ctx context.Context, rawFilter any, s *usecasex.Sort, p *usecasex.Pagination, filter any, consumer Consumer) (*usecasex.PageInfo, error) {
+
+	sortKey := idKey
+	sortOrder := 1
+	if s != nil && s.Key != "" {
+		sortKey = s.Key
+		if s.Reverted {
+			sortOrder = -1
+		}
+	}
+
+	if p.Cursor != nil && p.Cursor.Last != nil {
+		sortOrder *= -1
+	}
+
+	sort := bson.D{{Key: sortKey, Value: sortOrder}}
+	if sortKey != idKey {
+		sort = append(sort, bson.E{Key: idKey, Value: sortOrder})
+	}
+
+	findOpts := options.Find().
+		SetSort(sort).
+		SetLimit(limit(*p))
+
+	if p.Offset != nil {
+		findOpts.SetSkip(p.Offset.Offset)
+	}
+
+	cursor, err := c.collection.Find(ctx, filter, append([]*options.FindOptions{findOpts}, opts...)...)
+	if err != nil {
+		return nil, rerror.ErrInternalByWithContext(ctx, fmt.Errorf("failed to find: %w", err))
+	}
+	defer func() {
+		_ = cursor.Close(ctx)
+	}()
+
+	count, err := c.collection.CountDocuments(ctx, rawFilter)
+	if err != nil {
+		return nil, rerror.ErrInternalByWithContext(ctx, fmt.Errorf("failed to count: %w", err))
+	}
+
+	items, startCursor, endCursor, hasMore, err := consume(ctx, cursor, limit(*p))
+	if err != nil {
+		return nil, err
+	}
+
+	if p.Cursor != nil && p.Cursor.Last != nil {
+		reverse(items)
+		startCursor, endCursor = endCursor, startCursor
+	}
+
+	for _, item := range items {
+		if err := consumer.Consume(item); err != nil {
+			return nil, err
+		}
+	}
+
+	hasNextPage, hasPreviousPage := pageInfo(p, hasMore)
+
+	return usecasex.NewPageInfo(count, startCursor, endCursor, hasNextPage, hasPreviousPage), nil
 }

--- a/mongox/pagination.go
+++ b/mongox/pagination.go
@@ -27,7 +27,7 @@ func (c *Collection) Paginate(ctx context.Context, rawFilter any, s *usecasex.So
 		filter = And(rawFilter, "", pFilter)
 	}
 
-	return c.paginate(ctx, rawFilter, s, p, filter, consumer)
+	return c.paginate(ctx, rawFilter, s, p, filter, consumer, opts)
 }
 
 func (c *Collection) PaginateAggregation(ctx context.Context, pipeline []any, s *usecasex.Sort, p *usecasex.Pagination, consumer Consumer, opts ...*options.AggregateOptions) (*usecasex.PageInfo, error) {
@@ -286,11 +286,11 @@ func (c *Collection) PaginateProject(ctx context.Context, rawFilter any, s *usec
 		filter = AddCondition(rawFilter, "", pFilter)
 	}
 
-	return c.paginate(ctx, rawFilter, s, p, filter, consumer)
+	return c.paginate(ctx, rawFilter, s, p, filter, consumer, opts)
 
 }
 
-func (c *Collection) paginate(ctx context.Context, rawFilter any, s *usecasex.Sort, p *usecasex.Pagination, filter any, consumer Consumer) (*usecasex.PageInfo, error) {
+func (c *Collection) paginate(ctx context.Context, rawFilter any, s *usecasex.Sort, p *usecasex.Pagination, filter any, consumer Consumer, opts []*options.FindOptions) (*usecasex.PageInfo, error) {
 
 	sortKey := idKey
 	sortOrder := 1

--- a/mongox/util_test.go
+++ b/mongox/util_test.go
@@ -234,10 +234,7 @@ func TestAndProjectRefetchFilter(t *testing.T) {
 	condition := bson.M{
 		"$or": bson.A{
 			bson.M{"updatedat": bson.M{"$lt": updatedat}},
-			bson.M{
-				"id":        bson.M{"$lt": last},
-				"updatedat": updatedat,
-			},
+			bson.M{"id": bson.M{"$lt": last}, "updatedat": updatedat},
 		},
 	}
 
@@ -351,7 +348,8 @@ func TestAddConditionComplexFilter(t *testing.T) {
 			bson.M{"y": 20},
 			bson.M{"c": bson.M{"d": 3}},
 		},
-		"$or": bson.A{bson.M{"a": 1},
+		"$or": bson.A{
+			bson.M{"a": 1},
 			bson.M{"b": 2},
 		},
 	}
@@ -402,29 +400,29 @@ func TestAddConditionProjectRefetchFilter(t *testing.T) {
 	condition := bson.M{
 		"$or": bson.A{
 			bson.M{"updatedat": bson.M{"$lt": updatedat}},
-			bson.M{
-				"id":        bson.M{"$lt": last},
-				"updatedat": updatedat,
-			},
+			bson.M{"id": bson.M{"$lt": last}, "updatedat": updatedat},
 		},
 	}
 
 	expected := bson.M{
 		"$and": bson.A{
-			bson.M{"$or": bson.A{
-				bson.M{"deleted": false},
-				bson.M{"deleted": bson.M{"$exists": false}},
+			bson.M{
+				"$or": bson.A{
+					bson.M{"deleted": false},
+					bson.M{"deleted": bson.M{"$exists": false}},
+				},
 			},
+			bson.M{
+				"$or": bson.A{
+					bson.M{"coresupport": true},
+					bson.M{"coresupport": bson.M{"$exists": false}},
+				},
 			},
-			bson.M{"$or": bson.A{
-				bson.M{"coresupport": true},
-				bson.M{"coresupport": bson.M{"$exists": false}},
-			},
-			},
-			bson.M{"$or": bson.A{
-				bson.M{"updatedat": bson.M{"$lt": updatedat}},
-				bson.M{"id": bson.M{"$lt": last}, "updatedat": updatedat},
-			},
+			bson.M{
+				"$or": bson.A{
+					bson.M{"updatedat": bson.M{"$lt": updatedat}},
+					bson.M{"id": bson.M{"$lt": last}, "updatedat": updatedat},
+				},
 			},
 		},
 		"team": team,


### PR DESCRIPTION
# Projects from a different workspace are shown when fetching projects

This issue occurs when the pagination cursor is present in the project-fetching query.
In such cases, the cursor takes priority, and the top-level key conditions are dropped.

Note: This bug happens when there are more than 16 workspaces.

 ## Request from the frontend
For the first 16 items:
```json
{
  "Sort": {"Key": "updatedat", "Desc": true},
  "Keyword": null,
  "Pagination": {
    "Cursor": {"before": null, "after": null, "first": 16, "last": null},
    "Offset": null
  }
}
```
For items after the 16th:
```json
{
  "Sort": {"Key": "updatedat", "Desc": true},
  "Keyword": null,
  "Pagination": {
    "Cursor": {"before": null, "after": "01jawa0y3z9tk4haebh0h63p73", "first": 16, "last": null},
    "Offset": null
  }
}
```

## Query to MongoDB
For the first 16 items:
```diff
{
  "$and": [
    {
      "$or": [
        {"deleted": false},
        {"deleted": {"$exists": false}}
      ]
    },
    {
      "$or": [
        {"coresupport": true},
        {"coresupport": {"$exists": false}}
      ]
    }
  ],
  "team": "01g2s3wfhsm73ty0bbt5cy51f5"
}
```
For items after the 16th:

I have ensured that the top-level key (team) is included in the conditions even when a pagination cursor is present.
```diff
{
  "$and": [
    {
      "$or": [
        {"deleted": false},
        {"deleted": {"$exists": false}}
      ]
    },
    {
      "$or": [
        {"coresupport": true},
        {"coresupport": {"$exists": false}}
      ]
    },
    {
      "$or": [
        {"updatedat": {"$lt": "1654849072592"}},
        {"id": {"$lt": "01j72tv0erq2dqf8b0506sw4vk"}, "updatedat": "1654849072592"}
      ]
    }
  ],
+  "team": "01g2s3wfhsm73ty0bbt5cy51f5"
}
```

# The test code is here:

https://github.com/reearth/reearthx/blob/fix/original-key-filter/mongox/util_test.go#L212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to check for empty conditions in BSON types.
	- Enhanced the `AddCondition` function for improved filter management.
	- Streamlined the `And` function for better condition handling.
	- Added a new pagination method, `PaginateProject`, for enhanced document retrieval.

- **Bug Fixes**
	- Improved handling of `$and` operator for better condition management.

- **Tests**
	- Added multiple test cases for the `AddCondition` and `And` functions to validate various scenarios, ensuring robustness against different input cases.
	- Renamed existing test function for clarity.
	- Removed outdated test functions related to previous implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->