### PR TITLE
feat: add mock-permission-checker

### DIFF
--- a/cerbos/client/mock_permission_checker.go
+++ b/cerbos/client/mock_permission_checker.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"context"
+
+	"github.com/reearth/reearthx/appx"
+)
+
+type MockPermissionChecker struct {
+	Allow bool
+	Error error
+}
+
+func NewMockPermissionChecker() *MockPermissionChecker {
+	return &MockPermissionChecker{
+		Allow: true,
+		Error: nil,
+	}
+}
+
+func (m *MockPermissionChecker) CheckPermission(ctx context.Context, authInfo *appx.AuthInfo, resource string, action string) (bool, error) {
+	if m.Error != nil {
+		return false, m.Error
+	}
+	return m.Allow, nil
+}


### PR DESCRIPTION
Because mock is needed for e2e.