### PR TITLE
feat(server): Update user role with maintainer

### DIFF
--- a/account/accountusecase/accountinteractor/usecase.go
+++ b/account/accountusecase/accountinteractor/usecase.go
@@ -83,7 +83,6 @@ func Run3[A, B, C any](ctx context.Context, op *accountusecase.Operator, r *acco
 	if e.tx {
 		tr = r.Transaction
 	}
-
 	return usecasex.Run3(ctx, f, usecasex.TxUsecase{Transaction: tr}.UseTx(), e.EnsurePermission(op))
 }
 

--- a/account/accountusecase/operator.go
+++ b/account/accountusecase/operator.go
@@ -47,7 +47,7 @@ func (o *Operator) AllMaintainingWorkspaces() accountdomain.WorkspaceIDList {
 }
 
 func (o *Operator) AllOwningWorkspaces() accountdomain.WorkspaceIDList {
-	return o.OwningWorkspaces
+	return o.OwningWorkspaces.Concat(o.MaintainableWorkspaces)
 }
 
 func (o *Operator) IsReadableWorkspace(ws ...accountdomain.WorkspaceID) bool {
@@ -58,8 +58,8 @@ func (o *Operator) IsWritableWorkspace(ws ...accountdomain.WorkspaceID) bool {
 	return o.AllWritableWorkspaces().Intersect(ws).Len() > 0
 }
 
-func (o *Operator) IsMaintainingWorkspace(workspace ...accountdomain.WorkspaceID) bool {
-	return o.AllMaintainingWorkspaces().Intersect(workspace).Len() > 0
+func (o *Operator) IsMaintainingWorkspace(ws ...accountdomain.WorkspaceID) bool {
+	return o.AllMaintainingWorkspaces().Intersect(ws).Len() > 0
 }
 
 func (o *Operator) IsOwningWorkspace(ws ...accountdomain.WorkspaceID) bool {


### PR DESCRIPTION
## The maintainer user cannot update roles.

Currently, only WithOwnableWorkspaces() is being used, and WithMaintainableWorkspaces() is not called from anywhere.

```go
func (u *uc) WithMaintainableWorkspaces(ids ...accountdomain.WorkspaceID) *uc {
func (u *uc) WithOwnableWorkspaces(ids ...accountdomain.WorkspaceID) *uc {
```

The maintainableWorkspaces field in uc is not referenced anywhere.
```go
type uc struct {
	maintainableWorkspaces accountdomain.WorkspaceIDList
	ownableWorkspaces      accountdomain.WorkspaceIDList
}
```

This means that if a user has the "maintainer" role, they are not granted any permissions and will always receive "operation denied" errors.

To temporarily work around this issue, we can treat maintainers as equivalent to owners by modifying:

```go
func (o *Operator) AllOwningWorkspaces() accountdomain.WorkspaceIDList {
-	return o.OwningWorkspaces
+	return o.OwningWorkspaces.Concat(o.MaintainableWorkspaces)
}
```

However, this does not comply with the specifications described in the following document:
[User Role System](https://www.notion.so/eukarya/User-Role-System-18516e0fb16580a5b82bde38ae88318f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The account workspace view now displays a combined list of both owned and additionally managed workspaces for a more comprehensive overview.
  
- **Chores**
  - Streamlined internal account processing to enhance overall system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->