### PR TITLE
feat(server): Add FindByIntegrations for wokrspace in accountusecase

### DIFF
--- a/account/accountdomain/id.go
+++ b/account/accountdomain/id.go
@@ -18,6 +18,7 @@ type IntegrationID = idx.ID[Integration]
 
 type UserIDList = idx.List[User]
 type WorkspaceIDList = idx.List[Workspace]
+type IntegrationIDList = idx.List[Integration]
 
 var NewUserID = idx.New[User]
 var MustUserID = idx.Must[User]

--- a/account/accountdomain/user/id.go
+++ b/account/accountdomain/user/id.go
@@ -8,6 +8,8 @@ type ID = accountdomain.UserID
 type IDList = accountdomain.UserIDList
 type WorkspaceID = accountdomain.WorkspaceID
 type WorkspaceIDList = accountdomain.WorkspaceIDList
+type IntegrationID = accountdomain.IntegrationID
+type IntegrationIDList = accountdomain.IntegrationIDList
 
 var NewID = accountdomain.NewUserID
 var MustID = accountdomain.MustUserID

--- a/account/accountdomain/workspace/id.go
+++ b/account/accountdomain/workspace/id.go
@@ -7,6 +7,7 @@ type IDList = accountdomain.WorkspaceIDList
 type UserID = accountdomain.UserID
 type UserIDList = accountdomain.UserIDList
 type IntegrationID = accountdomain.IntegrationID
+type IntegrationIDList = accountdomain.IntegrationIDList
 
 var NewID = accountdomain.NewWorkspaceID
 var NewUserID = accountdomain.NewUserID

--- a/account/accountinfrastructure/accountmemory/workspace.go
+++ b/account/accountinfrastructure/accountmemory/workspace.go
@@ -6,6 +6,7 @@ import (
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
+	"github.com/reearth/reearthx/idx"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/util"
 	"golang.org/x/exp/slices"
@@ -52,6 +53,23 @@ func (r *Workspace) FindByIntegration(_ context.Context, i workspace.Integration
 	return rerror.ErrIfNil(r.data.FindAll(func(key workspace.ID, value *workspace.Workspace) bool {
 		return value.Members().HasIntegration(i)
 	}), rerror.ErrNotFound)
+}
+
+// FindByIntegrations finds workspace list based on integrations IDs
+func (r *Workspace) FindByIntegrations(_ context.Context, ids workspace.IntegrationIDList) (workspace.List, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	res := r.data.FindAll(func(key workspace.ID, value *workspace.Workspace) bool {
+		return value.Members().HasIntegration(idx.ID[accountdomain.Integration](key))
+	})
+	slices.SortFunc(res, func(a, b *workspace.Workspace) int { return a.ID().Compare(b.ID()) })
+	return res, nil
 }
 
 func (r *Workspace) FindByIDs(_ context.Context, ids workspace.IDList) (workspace.List, error) {

--- a/account/accountinfrastructure/accountmemory/workspace.go
+++ b/account/accountinfrastructure/accountmemory/workspace.go
@@ -6,7 +6,6 @@ import (
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
-	"github.com/reearth/reearthx/idx"
 	"github.com/reearth/reearthx/rerror"
 	"github.com/reearth/reearthx/util"
 	"golang.org/x/exp/slices"
@@ -66,9 +65,16 @@ func (r *Workspace) FindByIntegrations(_ context.Context, ids workspace.Integrat
 	}
 
 	res := r.data.FindAll(func(key workspace.ID, value *workspace.Workspace) bool {
-		return value.Members().HasIntegration(idx.ID[accountdomain.Integration](key))
+		for _, id := range ids {
+			if value.Members().HasIntegration(id) {
+				return true
+			}
+		}
+		return false
 	})
+
 	slices.SortFunc(res, func(a, b *workspace.Workspace) int { return a.ID().Compare(b.ID()) })
+
 	return res, nil
 }
 

--- a/account/accountinfrastructure/accountmemory/workspace.go
+++ b/account/accountinfrastructure/accountmemory/workspace.go
@@ -3,6 +3,8 @@ package accountmemory
 import (
 	"context"
 
+	slices0 "slices"
+
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
@@ -65,12 +67,7 @@ func (r *Workspace) FindByIntegrations(_ context.Context, ids workspace.Integrat
 	}
 
 	res := r.data.FindAll(func(key workspace.ID, value *workspace.Workspace) bool {
-		for _, id := range ids {
-			if value.Members().HasIntegration(id) {
-				return true
-			}
-		}
-		return false
+		return slices0.ContainsFunc(ids, value.Members().HasIntegration)
 	})
 
 	slices.SortFunc(res, func(a, b *workspace.Workspace) int { return a.ID().Compare(b.ID()) })

--- a/account/accountinfrastructure/accountmemory/workspace_test.go
+++ b/account/accountinfrastructure/accountmemory/workspace_test.go
@@ -70,6 +70,57 @@ func TestWorkspace_FindByIDs(t *testing.T) {
 	assert.Same(t, wantErr, r.Save(ctx, ws))
 }
 
+func TestWorkspace_FindByIntegrations(t *testing.T) {
+	ctx := context.Background()
+	i1 := workspace.NewIntegrationID()
+	i2 := workspace.NewIntegrationID()
+	ws := workspace.New().NewID().Name("hoge").Integrations(map[workspace.IntegrationID]workspace.Member{i1: {}}).MustBuild()
+	ws2 := workspace.New().NewID().Name("foo").Integrations(map[workspace.IntegrationID]workspace.Member{i2: {}}).MustBuild()
+	r := &Workspace{
+		data: &util.SyncMap[accountdomain.WorkspaceID, *workspace.Workspace]{},
+	}
+	r.data.Store(ws.ID(), ws)
+	r.data.Store(ws2.ID(), ws2)
+
+	type args struct {
+		ids workspace.IntegrationIDList
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    workspace.List
+		wantErr error
+	}{
+		{
+			name:    "Success",
+			args:    args{ids: workspace.IntegrationIDList{i2}},
+			want:    workspace.List{ws2},
+			wantErr: nil,
+		},
+		{
+			name:    "Success with multiple integrations",
+			args:    args{ids: workspace.IntegrationIDList{i1, i2}},
+			want:    workspace.List{ws, ws2},
+			wantErr: nil,
+		},
+		{
+			name:    "Success with empty integrations",
+			args:    args{ids: workspace.IntegrationIDList{}},
+			want:    nil,
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := r.FindByIntegrations(ctx, tc.args.ids)
+			assert.Equal(t, tc.wantErr, err)
+			assert.Equal(t, tc.want, out)
+		})
+	}
+}
+
 func TestWorkspace_FindByUser(t *testing.T) {
 	ctx := context.Background()
 	u := user.New().NewID().Name("aaa").Email("aaa@bbb.com").MustBuild()

--- a/account/accountinfrastructure/accountmongo/workspace.go
+++ b/account/accountinfrastructure/accountmongo/workspace.go
@@ -64,13 +64,13 @@ func (r *Workspace) FindByIntegrations(ctx context.Context, integrationIDs works
 		return nil, nil
 	}
 
-	orConditions := make([]bson.M, len(integrationIDs))
-	for i, id := range integrationIDs {
-		orConditions[i] = bson.M{
+	orConditions := make([]bson.M, 0)
+	for _, id := range integrationIDs {
+		orConditions = append(orConditions, bson.M{
 			"integrations." + strings.Replace(id.String(), ".", "", -1): bson.M{
 				"$exists": true,
 			},
-		}
+		})
 	}
 
 	return r.find(ctx, bson.M{

--- a/account/accountinfrastructure/accountmongo/workspace.go
+++ b/account/accountinfrastructure/accountmongo/workspace.go
@@ -59,13 +59,13 @@ func (r *Workspace) FindByIntegration(ctx context.Context, id workspace.Integrat
 }
 
 // FindByIntegrations finds workspace list based on integrations IDs
-func (r *Workspace) FindByIntegrations(ctx context.Context, ids workspace.IntegrationIDList) (workspace.List, error) {
-	if len(ids) == 0 {
+func (r *Workspace) FindByIntegrations(ctx context.Context, integrationIDs workspace.IntegrationIDList) (workspace.List, error) {
+	if len(integrationIDs) == 0 {
 		return nil, nil
 	}
 
-	orConditions := make([]bson.M, len(ids))
-	for i, id := range ids {
+	orConditions := make([]bson.M, len(integrationIDs))
+	for i, id := range integrationIDs {
 		orConditions[i] = bson.M{
 			"integrations." + strings.Replace(id.String(), ".", "", -1): bson.M{
 				"$exists": true,
@@ -73,7 +73,9 @@ func (r *Workspace) FindByIntegrations(ctx context.Context, ids workspace.Integr
 		}
 	}
 
-	return r.find(ctx, bson.M{"$or": orConditions})
+	return r.find(ctx, bson.M{
+		"$or": orConditions,
+	})
 }
 
 func (r *Workspace) FindByIDs(ctx context.Context, ids accountdomain.WorkspaceIDList) (workspace.List, error) {

--- a/account/accountinfrastructure/accountmongo/workspace.go
+++ b/account/accountinfrastructure/accountmongo/workspace.go
@@ -58,6 +58,24 @@ func (r *Workspace) FindByIntegration(ctx context.Context, id workspace.Integrat
 	})
 }
 
+// FindByIntegrations finds workspace list based on integrations IDs
+func (r *Workspace) FindByIntegrations(ctx context.Context, ids workspace.IntegrationIDList) (workspace.List, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	orConditions := make([]bson.M, len(ids))
+	for i, id := range ids {
+		orConditions[i] = bson.M{
+			"integrations." + strings.Replace(id.String(), ".", "", -1): bson.M{
+				"$exists": true,
+			},
+		}
+	}
+
+	return r.find(ctx, bson.M{"$or": orConditions})
+}
+
 func (r *Workspace) FindByIDs(ctx context.Context, ids accountdomain.WorkspaceIDList) (workspace.List, error) {
 	if len(ids) == 0 {
 		return nil, nil

--- a/account/accountinfrastructure/accountmongo/workspace_test.go
+++ b/account/accountinfrastructure/accountmongo/workspace_test.go
@@ -257,7 +257,13 @@ func TestWorkspace_FindByIntegrations(t *testing.T) {
 
 			got, err := repo.FindByIntegrations(ctx, tc.Input)
 			assert.NoError(tt, err)
-			assert.Len(tt, got, 0)
+			assert.Len(tt, got, len(tc.want))
+			for k, ws := range got {
+				if ws != nil {
+					assert.Equal(tt, tc.want[k].ID(), ws.ID())
+					assert.Equal(tt, tc.want[k].Name(), ws.Name())
+				}
+			}
 
 			err = repo.RemoveAll(ctx, accountdomain.WorkspaceIDList{ws1.ID(), ws2.ID()})
 			assert.NoError(t, err)

--- a/account/accountinfrastructure/accountmongo/workspace_test.go
+++ b/account/accountinfrastructure/accountmongo/workspace_test.go
@@ -241,11 +241,11 @@ func TestWorkspace_FindByIntegrations(t *testing.T) {
 	}
 
 	init := mongotest.Connect(t)
-	t.Parallel()
+
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.Name, func(tt *testing.T) {
-
+			tt.Parallel()
 			client := mongox.NewClientWithDatabase(init(t))
 
 			repo := NewWorkspace(client)

--- a/account/accountinfrastructure/accountmongo/workspace_test.go
+++ b/account/accountinfrastructure/accountmongo/workspace_test.go
@@ -241,10 +241,9 @@ func TestWorkspace_FindByIntegrations(t *testing.T) {
 	}
 
 	init := mongotest.Connect(t)
-
+	t.Parallel()
 	for _, tc := range tests {
 		tc := tc
-		t.Parallel()
 		t.Run(tc.Name, func(tt *testing.T) {
 
 			client := mongox.NewClientWithDatabase(init(t))

--- a/account/accountinfrastructure/accountmongo/workspace_test.go
+++ b/account/accountinfrastructure/accountmongo/workspace_test.go
@@ -235,8 +235,8 @@ func TestWorkspace_FindByIntegrations(t *testing.T) {
 
 	init := mongotest.Connect(t)
 
-	for _, tc := range tests {
-		tc := tc
+	for _, tt := range tests {
+		tc := tt
 
 		t.Run(tc.Name, func(tt *testing.T) {
 			tt.Parallel()

--- a/account/accountinfrastructure/accountmongo/workspace_test.go
+++ b/account/accountinfrastructure/accountmongo/workspace_test.go
@@ -192,10 +192,17 @@ func TestWorkspace_RemoveAll(t *testing.T) {
 }
 
 func TestWorkspace_FindByIntegrations(t *testing.T) {
+	u := user.New().Name("aaa").NewID().Email("aaa@bbb.com").MustBuild()
 	i1 := workspace.NewIntegrationID()
 	i2 := workspace.NewIntegrationID()
-	ws1 := workspace.New().NewID().Name("hoge").Integrations(map[workspace.IntegrationID]workspace.Member{i1: {}}).MustBuild()
-	ws2 := workspace.New().NewID().Name("foo").Integrations(map[workspace.IntegrationID]workspace.Member{i2: {}}).MustBuild()
+	ws1 := workspace.New().NewID().Name("hoge").Integrations(map[workspace.IntegrationID]workspace.Member{i1: {
+		Role:      workspace.RoleOwner,
+		InvitedBy: u.ID(),
+	}}).MustBuild()
+	ws2 := workspace.New().NewID().Name("foo").Integrations(map[workspace.IntegrationID]workspace.Member{i2: {
+		Role:      workspace.RoleOwner,
+		InvitedBy: u.ID(),
+	}}).MustBuild()
 
 	tests := []struct {
 		Name    string

--- a/account/accountinfrastructure/accountmongo/workspace_test.go
+++ b/account/accountinfrastructure/accountmongo/workspace_test.go
@@ -251,6 +251,9 @@ func TestWorkspace_FindByIntegrations(t *testing.T) {
 			got, err := repo.FindByIntegrations(ctx, tc.Input)
 			assert.NoError(tt, err)
 			assert.Len(tt, got, 0)
+
+			err = repo.RemoveAll(ctx, accountdomain.WorkspaceIDList{ws1.ID(), ws2.ID()})
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/account/accountinfrastructure/accountmongo/workspace_test.go
+++ b/account/accountinfrastructure/accountmongo/workspace_test.go
@@ -235,11 +235,11 @@ func TestWorkspace_FindByIntegrations(t *testing.T) {
 
 	init := mongotest.Connect(t)
 
-	for _, tt := range tests {
-		tc := tt
+	for _, tc := range tests {
+		tc := tc
 
 		t.Run(tc.Name, func(tt *testing.T) {
-			tt.Parallel()
+			t.Parallel()
 
 			client := mongox.NewClientWithDatabase(init(t))
 

--- a/account/accountinfrastructure/accountmongo/workspace_test.go
+++ b/account/accountinfrastructure/accountmongo/workspace_test.go
@@ -244,9 +244,8 @@ func TestWorkspace_FindByIntegrations(t *testing.T) {
 
 	for _, tc := range tests {
 		tc := tc
-
+		t.Parallel()
 		t.Run(tc.Name, func(tt *testing.T) {
-			t.Parallel()
 
 			client := mongox.NewClientWithDatabase(init(t))
 

--- a/account/accountusecase/accountrepo/workspace.go
+++ b/account/accountusecase/accountrepo/workspace.go
@@ -13,6 +13,8 @@ type Workspace interface {
 	FindByIDs(context.Context, workspace.IDList) (workspace.List, error)
 	FindByUser(context.Context, user.ID) (workspace.List, error)
 	FindByIntegration(context.Context, workspace.IntegrationID) (workspace.List, error)
+	// FindByIntegrations finds workspace list based on integrations IDs
+	FindByIntegrations(context.Context, workspace.IntegrationIDList) (workspace.List, error)
 	Create(context.Context, *workspace.Workspace) error
 	Save(context.Context, *workspace.Workspace) error
 	SaveAll(context.Context, workspace.List) error


### PR DESCRIPTION
Add FindByIntegrations for wokrspace in accountusecase to list wrokspaces based on integration IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced workspace search capabilities: Users can now query workspaces based on multiple integration identifiers.
  - Improved integration management: New identifier definitions have been added to better handle integration data consistently.
  - New methods in the workspace interface for retrieving workspaces based on integration IDs.

- **Tests**
  - Added new test functions to validate the functionality of the `FindByIntegrations` method for both memory and MongoDB implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->