### PR TITLE
fix(log): typo `letency` to `latency`

### DIFF
--- a/log/echo.go
+++ b/log/echo.go
@@ -252,7 +252,7 @@ func (l *Echo) AccessLogger() echo.MiddlewareFunc {
 			args = append(args,
 				"status", res.Status,
 				"bytes_out", res.Size,
-				"letency", latency.Microseconds(),
+				"latency", latency.Microseconds(),
 				"latency_human", latencyHuman,
 			)
 


### PR DESCRIPTION
# Why

Simple typo fix. I found it on the logs by chance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the logging functionality, ensuring that latency values are now recorded accurately. This change enhances the reliability of performance monitoring and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->