### PR TITLE
feat(validator,workspace): added name validator

### DIFF
--- a/account/accountdomain/workspace/workspace.go
+++ b/account/accountdomain/workspace/workspace.go
@@ -11,43 +11,47 @@ type Workspace struct {
 	location    string
 }
 
-func (t *Workspace) ID() ID {
-	return t.id
+func (w *Workspace) ID() ID {
+	return w.id
 }
 
-func (t *Workspace) Name() string {
-	return t.name
+func (w *Workspace) Name() string {
+	return w.name
 }
 
-func (t *Workspace) DisplayName() string {
-	return t.displayName
+func (w *Workspace) IsValidName(name string) bool {
+	return util.IsValidName(name)
 }
 
-func (t *Workspace) Members() *Members {
-	return t.members
+func (w *Workspace) DisplayName() string {
+	return w.displayName
 }
 
-func (t *Workspace) IsPersonal() bool {
-	return t.members.Fixed()
+func (w *Workspace) Members() *Members {
+	return w.members
 }
 
-func (t *Workspace) Location() string {
-	return t.location
+func (w *Workspace) IsPersonal() bool {
+	return w.members.Fixed()
 }
 
-func (t *Workspace) LocationOr(def string) string {
-	if t.location == "" {
+func (w *Workspace) Location() string {
+	return w.location
+}
+
+func (w *Workspace) LocationOr(def string) string {
+	if w.location == "" {
 		return def
 	}
-	return t.location
+	return w.location
 }
 
-func (t *Workspace) Rename(name string) {
-	t.name = name
+func (w *Workspace) Rename(name string) {
+	w.name = name
 }
 
-func (t *Workspace) UpdateDisplayName(displayName string) {
-	t.displayName = displayName
+func (w *Workspace) UpdateDisplayName(displayName string) {
+	w.displayName = displayName
 }
 
 func (w *Workspace) Policy() *PolicyID {

--- a/account/accountdomain/workspace/workspace_builder.go
+++ b/account/accountdomain/workspace/workspace_builder.go
@@ -7,6 +7,7 @@ import (
 )
 
 var ErrMembersRequired = errors.New("members required")
+var ErrInvalidName = errors.New("invalid name")
 
 type Builder struct {
 	w            *Workspace
@@ -61,6 +62,11 @@ func (b *Builder) NewID() *Builder {
 }
 
 func (b *Builder) Name(name string) *Builder {
+	if !b.w.IsValidName(name) {
+		b.err = ErrInvalidName
+		return b
+	}
+
 	b.w.name = name
 	return b
 }

--- a/account/accountusecase/accountinteractor/workspace_test.go
+++ b/account/accountusecase/accountinteractor/workspace_test.go
@@ -29,7 +29,7 @@ func TestWorkspace_Create(t *testing.T) {
 	_ = db.User.Save(ctx, u)
 	workspaceUC := NewWorkspace(db, nil)
 	op := &accountusecase.Operator{User: lo.ToPtr(u.ID())}
-	ws, err := workspaceUC.Create(ctx, "workspace name", u.ID(), op)
+	ws, err := workspaceUC.Create(ctx, "workspace_name", u.ID(), op)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, ws)
@@ -41,11 +41,11 @@ func TestWorkspace_Create(t *testing.T) {
 	assert.NotNil(t, resultWorkspaces)
 	assert.NotEmpty(t, resultWorkspaces)
 	assert.Equal(t, resultWorkspaces[0].ID(), ws.ID())
-	assert.Equal(t, resultWorkspaces[0].Name(), "workspace name")
+	assert.Equal(t, resultWorkspaces[0].Name(), "workspace_name")
 	assert.Equal(t, workspace.IDList{resultWorkspaces[0].ID()}, op.OwningWorkspaces)
 
 	// mock workspace error
-	wantErr := errors.New("test")
+	wantErr := errors.New("invalid name")
 	accountmemory.SetWorkspaceError(db.Workspace, wantErr)
 	workspace2, err := workspaceUC.Create(ctx, "workspace name 2", u.ID(), op)
 	assert.Nil(t, workspace2)

--- a/util/validator.go
+++ b/util/validator.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+)
+
+// IsValidName
+// Compatible with Auth0's restricted character set (subset only: lowercase letters, numbers, hyphens, underscores, at (@), and dots (.))
+// Regex explanation:
+// ^                 // Start of string
+// [a-z0-9]          // First character must be a lowercase letter or digit
+// (?:               // Start non-capturing group:
+//
+//	[a-z0-9-]{1,61}  // Allow 1 to 61 lowercase letters, digits, or hyphens
+//	[a-z0-9]         // Final character must be a lowercase letter or digit
+//
+// )?                // Group is optional to allow 1-character usernames
+// $                 // End of string
+//
+// Notes:
+// - Prevents leading/trailing hyphens
+// - Does not allow special characters beyond a-z, 0-9, hyphens, underscores, at (@), and dots (.)
+// - Safe for use in subdomains and URL path segments
+// - Does NOT allow consecutive hyphens; add extra logic in Go if needed
+func IsValidName(name string) bool {
+	name = strings.ToLower(name)
+	name = strings.TrimSpace(name)
+	nameRegex := regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-_@.]{0,61}[a-z0-9])?$`)
+	chars := []string{"-", "_", ".", "@"}
+
+	for _, c := range chars {
+		if strings.Contains(name, c+c) {
+			return false
+		}
+	}
+
+	// Check if it's an email address (not allowed)
+	if strings.Contains(name, "@") && strings.Contains(name, ".") {
+		return false
+	}
+
+	return nameRegex.MatchString(name)
+}

--- a/util/validator_test.go
+++ b/util/validator_test.go
@@ -1,0 +1,29 @@
+package util
+
+import "testing"
+
+func TestValidateName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"valid-name", true},
+		{"valid_name", true},
+		{"valid@name", true},
+		{"valid.name", true},
+		{"invalid--name", false},
+		{"invalid__name", false},
+		{"invalid..name", false},
+		{"invalid@@name", false},
+		{"invalid@name.com", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsValidName(test.name)
+			if result != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a validation mechanism for workspace names, ensuring they adhere to specific rules, and updates the relevant codebase to integrate this validation. The most important changes include adding a new `IsValidName` utility function, modifying the `Workspace` struct and builder to include validation, and updating tests to reflect the new constraints.

### Validation for Workspace Names:
* [`util/validator.go`](diffhunk://#diff-373427cf4e46a541209a8cf9b1cdad33f94edd1e56d07737ce14015cdc697837R1-R44): Added the `IsValidName` function to validate workspace names. It ensures names are compatible with a restricted character set, disallowing invalid patterns like consecutive special characters or email-like formats.
* [`util/validator_test.go`](diffhunk://#diff-a029282cb71b2070c2c3d3c24f79f65654ebc5a33d1fdc32bb275c3794968b51R1-R29): Added unit tests for `IsValidName` to verify its behavior with valid and invalid name examples.

### Updates to the `Workspace` Struct:
* [`account/accountdomain/workspace/workspace.go`](diffhunk://#diff-a4fbec11a1f4537c853fa96492ec329ba7df730e6d632fcca010ff0387d3301cL14-R54): Refactored the `Workspace` struct methods to use `w` instead of `t` as the receiver name. Added the `IsValidName` method to the `Workspace` struct.

### Integration into Workspace Builder:
* [`account/accountdomain/workspace/workspace_builder.go`](diffhunk://#diff-f45971037a82c3f487a8bc47985adfb1a5cab0db18008b27b41df7b9da4b99d3R10): Added the `ErrInvalidName` error and integrated `IsValidName` into the `Builder.Name` method to enforce name validation during workspace creation. [[1]](diffhunk://#diff-f45971037a82c3f487a8bc47985adfb1a5cab0db18008b27b41df7b9da4b99d3R10) [[2]](diffhunk://#diff-f45971037a82c3f487a8bc47985adfb1a5cab0db18008b27b41df7b9da4b99d3R65-R69)

### Test Updates:
* [`account/accountusecase/accountinteractor/workspace_test.go`](diffhunk://#diff-d38b73336404243686c972750506aebdeb58f137757f1d461cfe885de156e397L32-R32): Updated test cases to use valid workspace names and ensure errors are returned for invalid names. [[1]](diffhunk://#diff-d38b73336404243686c972750506aebdeb58f137757f1d461cfe885de156e397L32-R32) [[2]](diffhunk://#diff-d38b73336404243686c972750506aebdeb58f137757f1d461cfe885de156e397L44-R48)