### PR TITLE
ci: update golangci-lint version to v1.64.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.64.8
           args: --timeout=10m
       - name: test
         run: go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic -timeout 10m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: set up
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.24
       - name: checkout
         uses: actions/checkout@v3
       - name: cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: set up
         uses: actions/setup-go@v3
         with:
-          go-version: 1.24
+          go-version: 1.21
       - name: checkout
         uses: actions/checkout@v3
       - name: cache

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reearth/reearthx
 
-go 1.24
+go 1.21
 
 require (
 	github.com/99designs/gqlgen v0.17.43

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reearth/reearthx
 
-go 1.21
+go 1.24
 
 require (
 	github.com/99designs/gqlgen v0.17.43

--- a/idx/id_test.go
+++ b/idx/id_test.go
@@ -20,7 +20,7 @@ var dummyID = TID{nid: nid{id: dummyULID}}
 
 func TestNew(t *testing.T) {
 	id := New[T]()
-	assert.Equal(t, TID{nid: id.nid}, id)
+	assert.Equal(t, TID(id), id)
 	assert.NotZero(t, id.nid)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the golangci-lint tool in the CI workflow to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->