### PR TITLE
feat(workspace): added pagination to workspace by user [VIZ-1538]

### DIFF
--- a/account/accountusecase/accountrepo/workspace.go
+++ b/account/accountusecase/accountrepo/workspace.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
+	"github.com/reearth/reearthx/usecasex"
 )
 
 type Workspace interface {
@@ -13,6 +14,7 @@ type Workspace interface {
 	FindByName(context.Context, string) (*workspace.Workspace, error)
 	FindByIDs(context.Context, workspace.IDList) (workspace.List, error)
 	FindByUser(context.Context, user.ID) (workspace.List, error)
+	FindByUserWithPagination(ctx context.Context, id user.ID, pagination *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error)
 	FindByIntegration(context.Context, workspace.IntegrationID) (workspace.List, error)
 	// FindByIntegrations finds workspace list based on integrations IDs
 	FindByIntegrations(context.Context, workspace.IntegrationIDList) (workspace.List, error)


### PR DESCRIPTION
This pull request introduces a new method to support paginated retrieval of workspaces by user ID in the MongoDB-based workspace repository. It includes updates to the repository interface, implementation, and supporting utilities. Below is a summary of the most important changes:

### New Pagination Feature for Workspace Retrieval

* **Addition of `FindByUserWithPagination` method in repository implementation**: A new method, `FindByUserWithPagination`, was added to the `Workspace` repository implementation in `workspace.go`. This method enables paginated retrieval of workspaces associated with a specific user ID by leveraging a MongoDB filter and the `usecasex.Pagination` utility.
* **Introduction of `paginate` helper method**: A private `paginate` method was added to the `Workspace` repository implementation to handle the actual pagination logic using a consumer pattern and the `mongodoc.NewWorkspaceConsumer`.

### Interface Updates

* **Update to `Workspace` interface**: The `Workspace` interface in `accountrepo/workspace.go` was updated to include the new `FindByUserWithPagination` method, ensuring the interface supports the new functionality.

### Dependency Management

* **Import of `usecasex` package**: The `usecasex` package was imported in both `workspace.go` files to provide the `Pagination` and `PageInfo` types required for the new pagination functionality. [[1]](diffhunk://#diff-c3af14bef4ded6501862321babe7fd5b76b17a15464c1c9b885ed025cf4ab189R14) [[2]](diffhunk://#diff-930f0ff39f08b1384e43f8c84969bbaa7786e3b6b46be3334b01ebe838f07ca6R8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to view a paginated list of workspaces for a specific user, making it easier to navigate large numbers of workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->