### PR TITLE
feat(workspace): added pagination to workspace by user [VIZ-1538]

### DIFF
--- a/account/accountinfrastructure/accountmemory/workspace.go
+++ b/account/accountinfrastructure/accountmemory/workspace.go
@@ -55,10 +55,6 @@ func (r *Workspace) FindByUserWithPagination(ctx context.Context, id user.ID, pa
 		return nil, nil, r.err
 	}
 
-	if pagination == nil {
-		pagination = &usecasex.Pagination{}
-	}
-
 	workspaces := workspace.List(r.data.FindAll(func(key workspace.ID, value *workspace.Workspace) bool {
 		return value.Members().HasUser(id)
 	}))

--- a/account/accountusecase/accountrepo/workspace.go
+++ b/account/accountusecase/accountrepo/workspace.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
+	"github.com/reearth/reearthx/usecasex"
 )
 
 type Workspace interface {
@@ -13,6 +14,7 @@ type Workspace interface {
 	FindByName(context.Context, string) (*workspace.Workspace, error)
 	FindByIDs(context.Context, workspace.IDList) (workspace.List, error)
 	FindByUser(context.Context, user.ID) (workspace.List, error)
+	FindByUserWithPagination(ctx context.Context, id user.ID, pagination *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error)
 	FindByIntegration(context.Context, workspace.IntegrationID) (workspace.List, error)
 	// FindByIntegrations finds workspace list based on integrations IDs
 	FindByIntegrations(context.Context, workspace.IntegrationIDList) (workspace.List, error)


### PR DESCRIPTION
This pull request introduces a new feature to support paginated retrieval of workspaces associated with a specific user. It includes updates across multiple files to implement this functionality, along with corresponding tests. Below is a summary of the most important changes:

### Feature Implementation: Paginated Workspace Retrieval
* Added a new method `FindByUserWithPagination` to the `Workspace` interface in `accountrepo` to support paginated retrieval of user-associated workspaces. (`account/accountusecase/accountrepo/workspace.go`, [account/accountusecase/accountrepo/workspace.goR17](diffhunk://#diff-930f0ff39f08b1384e43f8c84969bbaa7786e3b6b46be3334b01ebe838f07ca6R17))
* Implemented the `FindByUserWithPagination` method in the in-memory repository (`accountmemory`) to handle pagination logic and return appropriate results. (`account/accountinfrastructure/accountmemory/workspace.go`, [account/accountinfrastructure/accountmemory/workspace.goR53-R80](diffhunk://#diff-d897a49991058feb29e865bfd54e8beabf62c9a4ce8f8c48202896357f7de24dR53-R80))
* Implemented the `FindByUserWithPagination` method in the MongoDB repository (`accountmongo`) using a helper function `paginate` to handle MongoDB-specific pagination logic. (`account/accountinfrastructure/accountmongo/workspace.go`, [[1]](diffhunk://#diff-c3af14bef4ded6501862321babe7fd5b76b17a15464c1c9b885ed025cf4ab189R54-R63) [[2]](diffhunk://#diff-c3af14bef4ded6501862321babe7fd5b76b17a15464c1c9b885ed025cf4ab189R214-R222)

### Supporting Changes
* Updated imports in relevant files to include the `usecasex` package, which provides pagination utilities. (`account/accountinfrastructure/accountmemory/workspace.go`, [[1]](diffhunk://#diff-d897a49991058feb29e865bfd54e8beabf62c9a4ce8f8c48202896357f7de24dL5-R12); `account/accountinfrastructure/accountmongo/workspace.go`, [[2]](diffhunk://#diff-c3af14bef4ded6501862321babe7fd5b76b17a15464c1c9b885ed025cf4ab189R14); `account/accountusecase/accountrepo/workspace.go`, [[3]](diffhunk://#diff-930f0ff39f08b1384e43f8c84969bbaa7786e3b6b46be3334b01ebe838f07ca6R8)
* Modified the `Filtered` method in `accountmemory` to prepare for future extensibility, though it currently returns the same instance. (`account/accountinfrastructure/accountmemory/workspace.go`, [account/accountinfrastructure/accountmemory/workspace.goL36-R40](diffhunk://#diff-d897a49991058feb29e865bfd54e8beabf62c9a4ce8f8c48202896357f7de24dL36-R40))

### Testing
* Added a new test `TestWorkspace_FindByUserWithPagination` in the MongoDB repository to validate the functionality of the `FindByUserWithPagination` method. The test ensures correct results for both existing and non-existing users. (`account/accountinfrastructure/accountmongo/workspace_test.go`, [account/accountinfrastructure/accountmongo/workspace_test.goR219-R268](diffhunk://#diff-becb2222103891c16bf6e310cf40a9947b4106af3037ea27e054ad1045f2da04R219-R268))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to view workspaces associated with a user using pagination, allowing users to browse workspaces in smaller, manageable chunks.

- **Tests**
	- Introduced new tests to ensure the correct behavior of paginated workspace retrieval by user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->