### PR TITLE
feature(user): added new fields to user and workspace

### DIFF
--- a/account/accountdomain/user/user.go
+++ b/account/accountdomain/user/user.go
@@ -16,8 +16,10 @@ var (
 type User struct {
 	id            ID
 	name          string
-	displayName   string
+	alias         string
+	description   string
 	email         string
+	website       string
 	password      EncodedPassword
 	workspace     WorkspaceID
 	auths         []Auth
@@ -36,15 +38,24 @@ func (u *User) Name() string {
 	return u.name
 }
 
-func (u *User) DisplayName() string {
-	if u.displayName == "" {
+func (u *User) Alias() string {
+	if u.alias == "" {
 		return u.name
 	}
-	return u.displayName
+
+	return u.alias
+}
+
+func (u *User) Description() string {
+	return u.description
 }
 
 func (u *User) Email() string {
 	return u.email
+}
+
+func (u *User) Website() string {
+	return u.website
 }
 
 func (u *User) Workspace() WorkspaceID {
@@ -67,12 +78,24 @@ func (u *User) UpdateName(name string) {
 	u.name = name
 }
 
+func (u *User) UpdateAlias(alias string) {
+	u.alias = alias
+}
+
+func (u *User) UpdateDescription(description string) {
+	u.description = description
+}
+
 func (u *User) UpdateEmail(email string) error {
 	if _, err := mail.ParseAddress(email); err != nil {
 		return ErrInvalidEmail
 	}
 	u.email = email
 	return nil
+}
+
+func (u *User) UpdateWebsite(website string) {
+	u.website = website
 }
 
 func (u *User) UpdateWorkspace(workspace WorkspaceID) {
@@ -85,10 +108,6 @@ func (u *User) UpdateLang(lang language.Tag) {
 
 func (u *User) UpdateTheme(t Theme) {
 	u.theme = t
-}
-
-func (u *User) UpdateDisplayName(displayName string) {
-	u.displayName = displayName
 }
 
 func (u *User) Verification() *Verification {
@@ -215,8 +234,10 @@ func (u *User) Clone() *User {
 	return &User{
 		id:            u.id,
 		name:          u.name,
-		displayName:   u.displayName,
+		alias:         u.alias,
+		description:   u.description,
 		email:         u.email,
+		website:       u.website,
 		password:      u.password,
 		workspace:     u.workspace,
 		auths:         slices.Clone(u.auths),

--- a/account/accountdomain/user/user_builder.go
+++ b/account/accountdomain/user/user_builder.go
@@ -72,8 +72,8 @@ func (b *Builder) Name(name string) *Builder {
 	return b
 }
 
-func (b *Builder) DisplayName(displayName string) *Builder {
-	b.u.displayName = displayName
+func (b *Builder) Alias(alias string) *Builder {
+	b.u.alias = alias
 	return b
 }
 

--- a/account/accountdomain/user/user_builder_test.go
+++ b/account/accountdomain/user/user_builder_test.go
@@ -35,9 +35,9 @@ func TestBuilder_Name(t *testing.T) {
 	assert.Equal(t, "xxx", b.Name())
 }
 
-func TestBuilder_DisplayName(t *testing.T) {
-	b := New().NewID().Name("aaa").DisplayName("xxx").Email("aaa@bbb.com").MustBuild()
-	assert.Equal(t, "xxx", b.DisplayName())
+func TestBuilder_Alias(t *testing.T) {
+	b := New().NewID().Name("aaa").Alias("xxx").Email("aaa@bbb.com").MustBuild()
+	assert.Equal(t, "xxx", b.Alias())
 }
 
 func TestBuilder_Workspace(t *testing.T) {

--- a/account/accountdomain/user/user_test.go
+++ b/account/accountdomain/user/user_test.go
@@ -24,7 +24,7 @@ func TestUser(t *testing.T) {
 
 	assert.Equal(t, u.id, u.ID())
 	assert.Equal(t, "xxx", u.Name())
-	assert.Equal(t, "xxx", u.DisplayName())
+	assert.Equal(t, "xxx", u.Alias())
 	assert.Equal(t, u.workspace, u.Workspace())
 	assert.Equal(t, Auths([]Auth{{
 		Provider: "aaa",
@@ -36,8 +36,8 @@ func TestUser(t *testing.T) {
 
 	u.UpdateName("a")
 	assert.Equal(t, "a", u.name)
-	assert.Equal(t, "", u.displayName)
-	assert.Equal(t, "a", u.DisplayName())
+	assert.Equal(t, "", u.alias)
+	assert.Equal(t, "a", u.Alias())
 	assert.ErrorContains(t, u.UpdateEmail("ab"), "invalid email")
 	assert.NoError(t, u.UpdateEmail("a@example.com"))
 	assert.Equal(t, "a@example.com", u.email)
@@ -45,8 +45,8 @@ func TestUser(t *testing.T) {
 	assert.Equal(t, language.Und, u.lang)
 	u.UpdateTheme(ThemeLight)
 	assert.Equal(t, ThemeLight, u.theme)
-	u.UpdateDisplayName("displayName")
-	assert.Equal(t, "displayName", u.displayName)
+	u.UpdateAlias("alias")
+	assert.Equal(t, "alias", u.alias)
 
 	wid := NewWorkspaceID()
 	u.UpdateWorkspace(wid)

--- a/account/accountdomain/workspace/workspace.go
+++ b/account/accountdomain/workspace/workspace.go
@@ -3,51 +3,51 @@ package workspace
 import "github.com/reearth/reearthx/util"
 
 type Workspace struct {
-	id          ID
-	name        string
-	displayName string
-	members     *Members
-	policy      *PolicyID
-	location    string
+	id       ID
+	name     string
+	alias    string
+	members  *Members
+	policy   *PolicyID
+	location string
 }
 
-func (t *Workspace) ID() ID {
-	return t.id
+func (w *Workspace) ID() ID {
+	return w.id
 }
 
-func (t *Workspace) Name() string {
-	return t.name
+func (w *Workspace) Name() string {
+	return w.name
 }
 
-func (t *Workspace) DisplayName() string {
-	return t.displayName
+func (w *Workspace) Alias() string {
+	return w.alias
 }
 
-func (t *Workspace) Members() *Members {
-	return t.members
+func (w *Workspace) Members() *Members {
+	return w.members
 }
 
-func (t *Workspace) IsPersonal() bool {
-	return t.members.Fixed()
+func (w *Workspace) IsPersonal() bool {
+	return w.members.Fixed()
 }
 
-func (t *Workspace) Location() string {
-	return t.location
+func (w *Workspace) Location() string {
+	return w.location
 }
 
-func (t *Workspace) LocationOr(def string) string {
-	if t.location == "" {
+func (w *Workspace) LocationOr(def string) string {
+	if w.location == "" {
 		return def
 	}
-	return t.location
+	return w.location
 }
 
-func (t *Workspace) Rename(name string) {
-	t.name = name
+func (w *Workspace) Rename(name string) {
+	w.name = name
 }
 
-func (t *Workspace) UpdateDisplayName(displayName string) {
-	t.displayName = displayName
+func (w *Workspace) UpdateAlias(alias string) {
+	w.alias = alias
 }
 
 func (w *Workspace) Policy() *PolicyID {

--- a/account/accountdomain/workspace/workspace_builder.go
+++ b/account/accountdomain/workspace/workspace_builder.go
@@ -65,8 +65,8 @@ func (b *Builder) Name(name string) *Builder {
 	return b
 }
 
-func (b *Builder) DisplayName(displayName string) *Builder {
-	b.w.displayName = displayName
+func (b *Builder) Alias(alias string) *Builder {
+	b.w.alias = alias
 	return b
 }
 

--- a/account/accountdomain/workspace/workspace_builder_test.go
+++ b/account/accountdomain/workspace/workspace_builder_test.go
@@ -39,9 +39,9 @@ func TestBuilder_Name(t *testing.T) {
 	assert.Equal(t, "xxx", w.w.name)
 }
 
-func TestBuilder_DisplayName(t *testing.T) {
-	w := New().DisplayName("xxx")
-	assert.Equal(t, "xxx", w.w.displayName)
+func TestBuilder_Alias(t *testing.T) {
+	w := New().Alias("xxx")
+	assert.Equal(t, "xxx", w.w.alias)
 }
 
 func TestBuilder_Build(t *testing.T) {

--- a/account/accountdomain/workspace/workspace_test.go
+++ b/account/accountdomain/workspace/workspace_test.go
@@ -14,8 +14,8 @@ func TestWorkspace_ID(t *testing.T) {
 func TestWorkspace_Name(t *testing.T) {
 	assert.Equal(t, "x", (&Workspace{name: "x"}).Name())
 }
-func TestWorkspace_DisplayName(t *testing.T) {
-	assert.Equal(t, "x", (&Workspace{displayName: "x"}).DisplayName())
+func TestWorkspace_Alias(t *testing.T) {
+	assert.Equal(t, "x", (&Workspace{alias: "x"}).Alias())
 }
 func TestWorkspace_Members(t *testing.T) {
 	m := NewMembersWith(map[UserID]Member{
@@ -38,10 +38,10 @@ func TestWorkspace_Rename(t *testing.T) {
 	assert.Equal(t, "a", w.name)
 }
 
-func TestWorkspace_UpdateDisplayName(t *testing.T) {
+func TestWorkspace_UpdateAlias(t *testing.T) {
 	w := &Workspace{}
-	w.UpdateDisplayName("a")
-	assert.Equal(t, "a", w.displayName)
+	w.UpdateAlias("a")
+	assert.Equal(t, "a", w.alias)
 }
 
 func TestWorkspace_Policy(t *testing.T) {

--- a/account/accountinfrastructure/accountmongo/mongodoc/user.go
+++ b/account/accountinfrastructure/accountmongo/mongodoc/user.go
@@ -16,8 +16,10 @@ type PasswordResetDocument struct {
 type UserDocument struct {
 	ID            string
 	Name          string
-	DisplayName   string
+	Alias         string
+	Description   string
 	Email         string
+	Website       string
 	Subs          []string
 	Workspace     string
 	Team          string `bson:",omitempty"`
@@ -62,8 +64,10 @@ func NewUser(user *user.User) (*UserDocument, string) {
 	return &UserDocument{
 		ID:            id,
 		Name:          user.Name(),
-		DisplayName:   user.DisplayName(),
+		Alias:         user.Alias(),
+		Description:   user.Description(),
 		Email:         user.Email(),
+		Website:       user.Website(),
 		Subs:          authsdoc,
 		Workspace:     user.Workspace().String(),
 		Lang:          user.Lang().String(),

--- a/account/accountinfrastructure/accountmongo/mongodoc/workspace.go
+++ b/account/accountinfrastructure/accountmongo/mongodoc/workspace.go
@@ -16,7 +16,7 @@ type WorkspaceMemberDocument struct {
 type WorkspaceDocument struct {
 	ID           string
 	Name         string
-	DisplayName  string
+	Alias        string
 	Members      map[string]WorkspaceMemberDocument
 	Integrations map[string]WorkspaceMemberDocument
 	Personal     bool
@@ -103,7 +103,7 @@ func (d *WorkspaceDocument) Model() (*workspace.Workspace, error) {
 	return workspace.New().
 		ID(tid).
 		Name(d.Name).
-		DisplayName(d.DisplayName).
+		Alias(d.Alias).
 		Members(members).
 		Integrations(integrations).
 		Personal(d.Personal).


### PR DESCRIPTION
This pull request refactors the `User` and `Workspace` domain models by replacing the `displayName` property with `alias` and introducing new properties like `description` and `website` for `User`. It also updates the corresponding methods, builders, and tests to align with these changes.

### Changes to `User` domain:

* Replaced `displayName` with `alias` and added new fields `description` and `website` in the `User` struct. Updated corresponding getter and setter methods. (`account/accountdomain/user/user.go`, [[1]](diffhunk://#diff-ab14bbe432c6fea338bf17ef803688f32db196ad0026c47e262cfa55ae1a224aL19-R22) [[2]](diffhunk://#diff-ab14bbe432c6fea338bf17ef803688f32db196ad0026c47e262cfa55ae1a224aL39-R60) [[3]](diffhunk://#diff-ab14bbe432c6fea338bf17ef803688f32db196ad0026c47e262cfa55ae1a224aR81-R88) [[4]](diffhunk://#diff-ab14bbe432c6fea338bf17ef803688f32db196ad0026c47e262cfa55ae1a224aR97-R100) [[5]](diffhunk://#diff-ab14bbe432c6fea338bf17ef803688f32db196ad0026c47e262cfa55ae1a224aL90-L93) [[6]](diffhunk://#diff-ab14bbe432c6fea338bf17ef803688f32db196ad0026c47e262cfa55ae1a224aL218-R240)
* Updated `Builder` to support `alias` instead of `displayName`. (`account/accountdomain/user/user_builder.go`, [account/accountdomain/user/user_builder.goL75-R76](diffhunk://#diff-7acf61615439b113bb18a0bdd0f160fd8ba69cbb40982320cb14a045f0f2a058L75-R76))
* Updated tests for `User` to reflect the changes in property names and behavior. (`account/accountdomain/user/user_builder_test.go`, [[1]](diffhunk://#diff-63b8f21b8ed3a066f7a2cf1dc9046e083516805ec42d2e6aeeff0bc6eee8f3f1L38-R40); `account/accountdomain/user/user_test.go`, [[2]](diffhunk://#diff-e1e8b40b63cfc5248a9b58a6ec5f0ee57f921a7070bba72d560ebb2e2f71fe01L27-R27) [[3]](diffhunk://#diff-e1e8b40b63cfc5248a9b58a6ec5f0ee57f921a7070bba72d560ebb2e2f71fe01L39-R49)

### Changes to `Workspace` domain:

* Replaced `displayName` with `alias` in the `Workspace` struct and updated corresponding methods. (`account/accountdomain/workspace/workspace.go`, [account/accountdomain/workspace/workspace.goL8-R50](diffhunk://#diff-a4fbec11a1f4537c853fa96492ec329ba7df730e6d632fcca010ff0387d3301cL8-R50))
* Updated `Builder` to support `alias` instead of `displayName`. (`account/accountdomain/workspace/workspace_builder.go`, [account/accountdomain/workspace/workspace_builder.goL68-R69](diffhunk://#diff-f45971037a82c3f487a8bc47985adfb1a5cab0db18008b27b41df7b9da4b99d3L68-R69))
* Updated tests for `Workspace` to reflect the changes in property names and behavior. (`account/accountdomain/workspace/workspace_builder_test.go`, [[1]](diffhunk://#diff-dc7860d9397cb182910abebb1535f5827dcb5652e9e8fdfeba7797b03d783db2L42-R44); `account/accountdomain/workspace/workspace_test.go`, [[2]](diffhunk://#diff-0d126383c74f9f849b1ad0826b3a54d2c9e4333239ee15fba0e4319cca481e58L17-R18) [[3]](diffhunk://#diff-0d126383c74f9f849b1ad0826b3a54d2c9e4333239ee15fba0e4319cca481e58L41-R44)

### MongoDB document changes:

* Updated `UserDocument` and `WorkspaceDocument` to replace `displayName` with `alias` and added support for the new fields (`description`, `website`) in `UserDocument`. Updated the conversion logic accordingly. (`account/accountinfrastructure/accountmongo/mongodoc/user.go`, [[1]](diffhunk://#diff-eee43d30e7824ed7b31d443df210417accaba44788c18ca1bb8617ca6c3ce362L19-R22) [[2]](diffhunk://#diff-eee43d30e7824ed7b31d443df210417accaba44788c18ca1bb8617ca6c3ce362L65-R70); `account/accountinfrastructure/accountmongo/mongodoc/workspace.go`, [[3]](diffhunk://#diff-be63f892e0cbda9faceffb271d736d9ec8d54406af2e88ae35b1eb03a8ae10a5L19-R19) [[4]](diffhunk://#diff-be63f892e0cbda9faceffb271d736d9ec8d54406af2e88ae35b1eb03a8ae10a5L106-R106)