### PR TITLE
chore(server): fix missing photo url

### DIFF
--- a/account/accountinfrastructure/accountmongo/mongodoc/workspace.go
+++ b/account/accountinfrastructure/accountmongo/mongodoc/workspace.go
@@ -59,6 +59,7 @@ func NewWorkspace(ws *workspace.Workspace) (*WorkspaceDocument, string) {
 			Website:      ws.Metadata().Website(),
 			Location:     ws.Metadata().Location(),
 			BillingEmail: ws.Metadata().BillingEmail(),
+			PhotoURL:     ws.Metadata().PhotoURL(),
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `NewWorkspace` function in `workspace.go` by including a new field, `PhotoURL`, in the `WorkspaceDocument`. This change ensures that the `PhotoURL` metadata from the workspace is now captured and stored.

* [`account/accountinfrastructure/accountmongo/mongodoc/workspace.go`](diffhunk://#diff-be63f892e0cbda9faceffb271d736d9ec8d54406af2e88ae35b1eb03a8ae10a5R62): Added the `PhotoURL` field to the `WorkspaceDocument` to store the workspace's photo URL metadata.