### PR TITLE
fix(server):role & permittable initialization [VIZ-1840]

### DIFF
--- a/account/accountinfrastructure/accountmongo/container.go
+++ b/account/accountinfrastructure/accountmongo/container.go
@@ -55,6 +55,8 @@ func Init(r *accountrepo.Container) error {
 	return util.Try(
 		r.Workspace.(*Workspace).Init,
 		r.User.(*User).Init,
+		r.Role.(*Role).Init,
+		r.Permittable.(*Permittable).Init,
 	)
 }
 

--- a/account/accountinfrastructure/accountmongo/permittable.go
+++ b/account/accountinfrastructure/accountmongo/permittable.go
@@ -30,8 +30,8 @@ func NewPermittable(client *mongox.Client) accountrepo.Permittable {
 	}
 }
 
-func (r *Permittable) Init(ctx context.Context) error {
-	return createIndexes(ctx, r.client, newPermittableIndexes, newPermittableUniqueIndexes)
+func (r *Permittable) Init() error {
+	return createIndexes(context.Background(), r.client, newPermittableIndexes, newPermittableUniqueIndexes)
 }
 
 func (r *Permittable) FindByUserID(ctx context.Context, id user.ID) (*permittable.Permittable, error) {

--- a/account/accountinfrastructure/accountmongo/role.go
+++ b/account/accountinfrastructure/accountmongo/role.go
@@ -28,8 +28,8 @@ func NewRole(client *mongox.Client) accountrepo.Role {
 	}
 }
 
-func (r *Role) Init(ctx context.Context) error {
-	return createIndexes(ctx, r.client, roleIndexes, roleUniqueIndexes)
+func (r *Role) Init() error {
+	return createIndexes(context.Background(), r.client, roleIndexes, roleUniqueIndexes)
 }
 
 func (r *Role) FindAll(ctx context.Context) (role.List, error) {


### PR DESCRIPTION
This pull request updates initialization logic for `Role` and `Permittable` in the `accountmongo` package, ensuring consistent handling of context and index creation. The most important changes include modifying the `Init` methods to remove the `ctx` parameter and updating the `Init` function in the `container.go` file to include initialization for `Role` and `Permittable`.

### Updates to initialization logic:

* [`account/accountinfrastructure/accountmongo/container.go`](diffhunk://#diff-564b82fe09d8a99c64855b17ea4eb68c3617855acccec430b702959cf1a38037R58-R59): Added calls to initialize `Role` and `Permittable` within the `Init` function, ensuring all components are properly initialized.
* [`account/accountinfrastructure/accountmongo/permittable.go`](diffhunk://#diff-eb1c43cf5195a42e2a9070251bc02344af33bbd9bf8e4016c11459ab8f781ee6L33-R34): Updated the `Init` method in `Permittable` to remove the `ctx` parameter and use a `context.Background()` instead, simplifying the initialization process.
* [`account/accountinfrastructure/accountmongo/role.go`](diffhunk://#diff-4e4c38b62fc1ecc51378c3bcc1868d5e00f7e888473f73ef103c1349d72d1d69L31-R32): Updated the `Init` method in `Role` to remove the `ctx` parameter and use a `context.Background()` instead, aligning it with the changes in `Permittable`.