### PR TITLE
chore(server): ignore name & alias on signup

### DIFF
--- a/account/accountdomain/user/user.go
+++ b/account/accountdomain/user/user.go
@@ -35,10 +35,6 @@ func (u *User) Name() string {
 }
 
 func (u *User) Alias() string {
-	if u.alias == "" {
-		return u.name
-	}
-
 	return u.alias
 }
 

--- a/account/accountdomain/user/user_builder.go
+++ b/account/accountdomain/user/user_builder.go
@@ -27,9 +27,6 @@ func (b *Builder) Build() (*User, error) {
 	if b.u.id.IsEmpty() {
 		return nil, ErrInvalidID
 	}
-	if b.u.name == "" {
-		return nil, ErrInvalidName
-	}
 	if b.passwordText != "" {
 		if err := b.u.SetPassword(b.passwordText); err != nil {
 			return nil, err

--- a/account/accountusecase/accountinteractor/user_signup_test.go
+++ b/account/accountusecase/accountinteractor/user_signup_test.go
@@ -236,15 +236,6 @@ func TestUser_Signup(t *testing.T) {
 			},
 			wantError: user.ErrPasswordLength,
 		},
-		{
-			name: "invalid name",
-			args: accountinterfaces.SignupParam{
-				Email:    "aaa@bbb.com",
-				Name:     "",
-				Password: "Ass00!!",
-			},
-			wantError: user.ErrInvalidName,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request simplifies the `User` domain logic by removing the validation for empty `name` fields and consolidating related code. The changes affect the `Alias` method, the `Build` method in the `UserBuilder`, and the corresponding test cases.

### Simplifications to `User` domain logic:

* **Removed fallback logic in `Alias` method**: The `Alias` method no longer checks if `alias` is empty and defaults to `name`. It now directly returns `alias`. (`account/accountdomain/user/user.go`, [account/accountdomain/user/user.goL38-L41](diffhunk://#diff-ab14bbe432c6fea338bf17ef803688f32db196ad0026c47e262cfa55ae1a224aL38-L41))
* **Removed `name` validation in `Build` method**: The `UserBuilder` no longer validates whether `name` is empty during user creation. (`account/accountdomain/user/user_builder.go`, [account/accountdomain/user/user_builder.goL30-L32](diffhunk://#diff-7acf61615439b113bb18a0bdd0f160fd8ba69cbb40982320cb14a045f0f2a058L30-L32))
* **Removed test case for invalid `name`**: The test case for empty `name` validation was removed, as this validation is no longer part of the logic. (`account/accountusecase/accountinteractor/user_signup_test.go`, [account/accountusecase/accountinteractor/user_signup_test.goL239-L247](diffhunk://#diff-098cd308894d0637182a9f7dbeeac3946b637e99b7aeed5d4f764aea288d99e0L239-L247))