### PR TITLE
chore(server): fix metadata nil after signup [VIZ-1859]

### DIFF
--- a/account/accountdomain/workspace/initializer.go
+++ b/account/accountdomain/workspace/initializer.go
@@ -58,6 +58,7 @@ func Init(p InitParams) (*user.User, *Workspace, error) {
 		Name(p.Name).
 		Members(map[user.ID]Member{u.ID(): {Role: RoleOwner, Disabled: false, InvitedBy: u.ID()}}).
 		Personal(true).
+		Metadata(NewMetadata()).
 		Build()
 	if err != nil {
 		return nil, nil, err

--- a/account/accountusecase/accountinteractor/user_signup_test.go
+++ b/account/accountusecase/accountinteractor/user_signup_test.go
@@ -70,6 +70,7 @@ func TestUser_Signup(t *testing.T) {
 				Name("NAME").
 				Members(map[user.ID]workspace.Member{uid: {Role: workspace.RoleOwner, Disabled: false, InvitedBy: uid}}).
 				Personal(true).
+				Metadata(workspace.NewMetadata()).
 				MustBuild(),
 			wantMailTo:      []mailer.Contact{{Email: "aaa@bbb.com", Name: "NAME"}},
 			wantMailSubject: "email verification",
@@ -148,6 +149,7 @@ func TestUser_Signup(t *testing.T) {
 				Name("NAME").
 				Members(map[user.ID]workspace.Member{uid: {Role: workspace.RoleOwner, Disabled: false, InvitedBy: uid}}).
 				Personal(true).
+				Metadata(workspace.NewMetadata()).
 				MustBuild(),
 			wantMailTo:      []mailer.Contact{{Email: "aaa@bbb.com", Name: "NAME"}},
 			wantMailSubject: "email verification",
@@ -189,6 +191,7 @@ func TestUser_Signup(t *testing.T) {
 				Name("NAME").
 				Members(map[user.ID]workspace.Member{uid: {Role: workspace.RoleOwner, Disabled: false, InvitedBy: uid}}).
 				Personal(true).
+				Metadata(workspace.NewMetadata()).
 				MustBuild(),
 			wantMailTo:      []mailer.Contact{{Email: "aaa@bbb.com", Name: "NAME"}},
 			wantMailSubject: "email verification",


### PR DESCRIPTION
This pull request introduces changes to ensure that `Metadata` is consistently initialized when creating workspaces. The `Metadata` field is now explicitly set using `NewMetadata()` in both the workspace initialization logic and related test cases.

### Workspace Initialization Enhancements:
* [`account/accountdomain/workspace/initializer.go`](diffhunk://#diff-00be63d7bcc9eeec25343d9595a8ced860bbd8c887e2284b229b5dfb1ffa665aR61): Added `Metadata(NewMetadata())` to the workspace builder in the `Init` function to ensure metadata is initialized during workspace creation.

### Test Updates for Metadata Initialization:
* [`account/accountusecase/accountinteractor/user_signup_test.go`](diffhunk://#diff-098cd308894d0637182a9f7dbeeac3946b637e99b7aeed5d4f764aea288d99e0R73): Updated multiple test cases in `TestUser_Signup` to include `Metadata(workspace.NewMetadata())` in the workspace builder, aligning tests with the new initialization logic. [[1]](diffhunk://#diff-098cd308894d0637182a9f7dbeeac3946b637e99b7aeed5d4f764aea288d99e0R73) [[2]](diffhunk://#diff-098cd308894d0637182a9f7dbeeac3946b637e99b7aeed5d4f764aea288d99e0R152) [[3]](diffhunk://#diff-098cd308894d0637182a9f7dbeeac3946b637e99b7aeed5d4f764aea288d99e0R194)