### PR TITLE
chore: add metadata when create workspace

### DIFF
--- a/account/accountusecase/accountinteractor/workspace.go
+++ b/account/accountusecase/accountinteractor/workspace.go
@@ -67,6 +67,7 @@ func (i *Workspace) Create(ctx context.Context, name string, firstUser workspace
 		ws, err := workspace.New().
 			NewID().
 			Name(name).
+			Metadata(workspace.NewMetadata()).
 			Build()
 		if err != nil {
 			return nil, err

--- a/asset/infrastructure/mongo/common_test.go
+++ b/asset/infrastructure/mongo/common_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func init() {
-	mongotest.Env = "REEARTH_CMS_DB"
+	mongotest.Env = "REEARTH_DB"
 }

--- a/asset/infrastructure/mongo/mongogit/collection_test.go
+++ b/asset/infrastructure/mongo/mongogit/collection_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	mongotest.Env = "REEARTH_CMS_DB"
+	mongotest.Env = "REEARTH_DB"
 }
 
 func TestCollection_FindOne(t *testing.T) {


### PR DESCRIPTION
This pull request includes updates to the workspace creation process and changes to the environment variable used in MongoDB-related tests. Below is a summary of the most important changes:

### Workspace Creation Enhancements:
* [`account/accountusecase/accountinteractor/workspace.go`](diffhunk://#diff-c1706f824cf54aabc902ce4c9c607d40d0c4ed2579bdf8b84ddcc0ff10471c49R70): Added a call to `Metadata(workspace.NewMetadata())` during workspace creation to initialize metadata for new workspaces.

### Environment Variable Updates in Tests:
* [`asset/infrastructure/mongo/common_test.go`](diffhunk://#diff-6a69d7451c858edee4fed81725ee630a0695efa6ede251776a1dccbd512ee57eL8-R8): Updated the `mongotest.Env` variable from `"REEARTH_CMS_DB"` to `"REEARTH_DB"` for consistency.
* [`asset/infrastructure/mongo/mongogit/collection_test.go`](diffhunk://#diff-9d7d007060f5f9ecafa16b4f04e0e8d39ee2522e223738c13b9479c5ee6500a1L22-R22): Similarly, updated the `mongotest.Env` variable from `"REEARTH_CMS_DB"` to `"REEARTH_DB"` in this test file.