### PR TITLE
chore: change metadata pointer to reference

### DIFF
--- a/account/accountinfrastructure/accountmongo/mongodoc/workspace.go
+++ b/account/accountinfrastructure/accountmongo/mongodoc/workspace.go
@@ -52,7 +52,7 @@ func NewWorkspace(ws *workspace.Workspace) (*WorkspaceDocument, string) {
 		}
 	}
 
-	var metadataDoc *WorkspaceMetadataDocument
+	metadataDoc := &WorkspaceMetadataDocument{}
 	if ws.Metadata() != nil {
 		metadataDoc = &WorkspaceMetadataDocument{
 			Description:  ws.Metadata().Description(),
@@ -122,7 +122,7 @@ func (d *WorkspaceDocument) Model() (*workspace.Workspace, error) {
 		policy = workspace.PolicyID(d.Policy).Ref()
 	}
 
-	var metadata *workspace.Metadata
+	metadata := &workspace.Metadata{}
 	if d.Metadata != nil {
 		metadata = workspace.MetadataFrom(d.Metadata.Description, d.Metadata.Website, d.Metadata.Location, d.Metadata.BillingEmail, d.Metadata.PhotoURL)
 	}


### PR DESCRIPTION
This pull request makes minor adjustments to the handling of metadata in the `workspace.go` file. Specifically, it initializes metadata-related variables with empty struct instances instead of `nil`.

### Changes to metadata handling:

* [`func NewWorkspace`](diffhunk://#diff-be63f892e0cbda9faceffb271d736d9ec8d54406af2e88ae35b1eb03a8ae10a5L55-R55): Changed the initialization of `metadataDoc` from `nil` to an empty `WorkspaceMetadataDocument` struct.
* [`func (d *WorkspaceDocument) Model`](diffhunk://#diff-be63f892e0cbda9faceffb271d736d9ec8d54406af2e88ae35b1eb03a8ae10a5L125-R125): Changed the initialization of `metadata` from `nil` to an empty `workspace.Metadata` struct.