### PR TITLE
chore(server): implement FindByIDsWithPagination method for user retrieval

### DIFF
--- a/account/accountusecase/accountrepo/multiuser.go
+++ b/account/accountusecase/accountrepo/multiuser.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearthx/usecasex"
 )
 
 type MultiUser []User
@@ -44,6 +45,24 @@ func (u MultiUser) FindByIDs(ctx context.Context, ids user.IDList) (user.List, e
 		}
 	}
 	return res, nil
+}
+
+func (u MultiUser) FindByIDsWithPagination(ctx context.Context, list user.IDList, pagination *usecasex.Pagination) (user.List, *usecasex.PageInfo, error) {
+	res := user.List{}
+	var pageInfo *usecasex.PageInfo
+	for _, r := range u {
+		if r, pi, err := r.FindByIDsWithPagination(ctx, list, pagination); err != nil {
+			return nil, nil, err
+		} else {
+			res = append(res, r...)
+			if pageInfo == nil {
+				pageInfo = pi
+			} else {
+				pageInfo.TotalCount += pi.TotalCount
+			}
+		}
+	}
+	return res, pageInfo, nil
 }
 
 func (u MultiUser) FindBySub(ctx context.Context, sub string) (*user.User, error) {

--- a/account/accountusecase/accountrepo/user.go
+++ b/account/accountusecase/accountrepo/user.go
@@ -6,6 +6,7 @@ import (
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/i18n"
 	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearthx/usecasex"
 )
 
 var ErrDuplicatedUser = rerror.NewE(i18n.T("duplicated user"))
@@ -24,6 +25,7 @@ type UserQuery interface {
 	FindAll(context.Context) (user.List, error)
 	FindByID(context.Context, user.ID) (*user.User, error)
 	FindByIDs(context.Context, user.IDList) (user.List, error)
+	FindByIDsWithPagination(context.Context, user.IDList, *usecasex.Pagination) (user.List, *usecasex.PageInfo, error)
 	FindBySub(context.Context, string) (*user.User, error)
 	FindByEmail(context.Context, string) (*user.User, error)
 	FindByName(context.Context, string) (*user.User, error)


### PR DESCRIPTION
This pull request introduces a new feature to support paginated queries for finding users by their IDs across multiple layers of the codebase. The changes include adding a `FindByIDsWithPagination` method to various user repository implementations, updating the related interfaces, and providing comprehensive tests for both in-memory and MongoDB-backed repositories.

### Core Feature: Pagination Support for User Queries
1. **New Method in Repositories**:
   - Added `FindByIDsWithPagination` method to `User` repositories in both `accountmemory` and `accountmongo` implementations. This method supports offset and cursor-based pagination and returns paginated results along with `PageInfo`. (`[[1]](diffhunk://#diff-d0157e0283c4d2f1fcd9d5e4843f1268697b3a75f7fb5ecb4570e258ccc76c7bR57-R118)`, `[[2]](diffhunk://#diff-959ca4248bbe95559c1f5febd9a98a1e28e27f572f62eca4a8096f1ff4359e1eR68-R75)`, `[[3]](diffhunk://#diff-959ca4248bbe95559c1f5febd9a98a1e28e27f572f62eca4a8096f1ff4359e1eR224-R232)`)
   - Implemented the method in `MultiUser` to aggregate results from multiple repositories. (`[account/accountusecase/accountrepo/multiuser.goR50-R67](diffhunk://#diff-f1c6baa4fe8a906b6a5959302f56650bcf832a22392fa2337f53a909d29d800fR50-R67)`)

2. **Interface Update**:
   - Updated the `UserQuery` interface to include the `FindByIDsWithPagination` method. (`[account/accountusecase/accountrepo/user.goR28](diffhunk://#diff-26a95a6e65c1b0fe370dd70c5e4376cab6a7c47c4310f85436b4ded9abccb113R28)`)

### Testing Enhancements
1. **In-Memory Repository Tests**:
   - Added unit tests for `FindByIDsWithPagination` in the in-memory repository, covering various pagination scenarios such as offset, cursor, and edge cases. (`[account/accountinfrastructure/accountmemory/user_test.goR454-R623](diffhunk://#diff-6a2a282fd9a3bd44d6a2e8cc4f590e23e059236438c7f1abb6469ce645f327baR454-R623)`)

2. **MongoDB Repository Tests**:
   - Added tests for the MongoDB-backed repository to validate the `FindByIDsWithPagination` functionality, ensuring compatibility with MongoDB's pagination mechanisms. (`[account/accountinfrastructure/accountmongo/user_test.goR639-R780](diffhunk://#diff-b8b6dbdff253df89c6235d205d37d0f3f2fbe25512ff9c652ebb0c949a22e901R639-R780)`)

### Dependency Updates
1. **New Dependency**:
   - Introduced the `usecasex` package to handle pagination logic and `PageInfo` structure. This was added to multiple files across the codebase. (`[[1]](diffhunk://#diff-d0157e0283c4d2f1fcd9d5e4843f1268697b3a75f7fb5ecb4570e258ccc76c7bR10)`, `[[2]](diffhunk://#diff-6a2a282fd9a3bd44d6a2e8cc4f590e23e059236438c7f1abb6469ce645f327baR13)`, `[[3]](diffhunk://#diff-959ca4248bbe95559c1f5febd9a98a1e28e27f572f62eca4a8096f1ff4359e1eR13)`, `[[4]](diffhunk://#diff-f1c6baa4fe8a906b6a5959302f56650bcf832a22392fa2337f53a909d29d800fR9)`, `[[5]](diffhunk://#diff-26a95a6e65c1b0fe370dd70c5e4376cab6a7c47c4310f85436b4ded9abccb113R9)`)

These changes collectively enhance the flexibility and scalability of user queries by enabling efficient pagination, which is crucial for handling large datasets.