### PR TITLE
add workspace alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TEST_DIR ?= ./...
+
 help:
 	@echo "Usage:"
 	@echo "  make <target>"
@@ -11,5 +13,14 @@ lint:
 
 test:
 	go test -race -short -v ./...
+
+test-debug:
+	go test -v -timeout 10s ${TEST_DIR} | tee test.log
+
+gql:
+	cd account && go generate ./...
+
+gql-client:
+	cd account/accountusecase/accountproxy && go generate
 
 .PHONY: lint test

--- a/account/accountinfrastructure/accountmemory/workspace.go
+++ b/account/accountinfrastructure/accountmemory/workspace.go
@@ -148,6 +148,10 @@ func (r *Workspace) FindByAlias(_ context.Context, alias string) (*workspace.Wor
 	}), rerror.ErrNotFound)
 }
 
+func (r *Workspace) CheckWorkspaceAliasUnique(ctx context.Context, excludeSelfWorkspaceID workspace.ID, alias string) error {
+	return nil
+}
+
 func (r *Workspace) Create(_ context.Context, t *workspace.Workspace) error {
 	if r.err != nil {
 		return r.err

--- a/account/accountinfrastructure/accountmongo/workspace.go
+++ b/account/accountinfrastructure/accountmongo/workspace.go
@@ -2,6 +2,7 @@ package accountmongo
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/reearth/reearthx/account/accountdomain"
@@ -147,6 +148,25 @@ func (r *Workspace) FindByAlias(ctx context.Context, alias string) (*workspace.W
 		return nil, rerror.ErrNotFound
 	}
 	return w, nil
+}
+
+func (r *Workspace) CheckWorkspaceAliasUnique(ctx context.Context, excludeSelfWorkspaceID workspace.ID, alias string) error {
+
+	filter := bson.M{
+		"alias": alias,
+		"id":    bson.M{"$ne": excludeSelfWorkspaceID.String()},
+	}
+
+	count, err := r.client.Count(ctx, filter)
+	if err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return errors.New("alias is already used in another workspace")
+	}
+
+	return nil
 }
 
 func (r *Workspace) Create(ctx context.Context, workspace *workspace.Workspace) error {

--- a/account/accountusecase/accountinterfaces/workspace.go
+++ b/account/accountusecase/accountinterfaces/workspace.go
@@ -20,8 +20,8 @@ var (
 type Workspace interface {
 	Fetch(context.Context, workspace.IDList, *accountusecase.Operator) (workspace.List, error)
 	FindByUser(context.Context, user.ID, *accountusecase.Operator) (workspace.List, error)
-	Create(context.Context, string, user.ID, *accountusecase.Operator) (*workspace.Workspace, error)
-	Update(context.Context, workspace.ID, string, *accountusecase.Operator) (*workspace.Workspace, error)
+	Create(context.Context, string, user.ID, *string, *accountusecase.Operator) (*workspace.Workspace, error)
+	Update(context.Context, workspace.ID, string, *string, *accountusecase.Operator) (*workspace.Workspace, error)
 	AddUserMember(context.Context, workspace.ID, map[user.ID]workspace.Role, *accountusecase.Operator) (*workspace.Workspace, error)
 	AddIntegrationMember(context.Context, workspace.ID, workspace.IntegrationID, workspace.Role, *accountusecase.Operator) (*workspace.Workspace, error)
 	UpdateUserMember(context.Context, workspace.ID, user.ID, workspace.Role, *accountusecase.Operator) (*workspace.Workspace, error)

--- a/account/accountusecase/accountproxy/generated.go
+++ b/account/accountusecase/accountproxy/generated.go
@@ -387,11 +387,15 @@ func (v *CreateWorkspaceCreateWorkspaceCreateWorkspacePayloadWorkspace) __premar
 }
 
 type CreateWorkspaceInput struct {
-	Name string `json:"name"`
+	Name  string `json:"name"`
+	Alias string `json:"alias"`
 }
 
 // GetName returns CreateWorkspaceInput.Name, and is useful for accessing the field via an interface.
 func (v *CreateWorkspaceInput) GetName() string { return v.Name }
+
+// GetAlias returns CreateWorkspaceInput.Alias, and is useful for accessing the field via an interface.
+func (v *CreateWorkspaceInput) GetAlias() string { return v.Alias }
 
 // CreateWorkspaceResponse is returned by CreateWorkspace on success.
 type CreateWorkspaceResponse struct {
@@ -2418,6 +2422,7 @@ func (v *UpdateUserOfWorkspaceUpdateUserOfWorkspaceUpdateMemberOfWorkspacePayloa
 type UpdateWorkspaceInput struct {
 	WorkspaceId string `json:"workspaceId"`
 	Name        string `json:"name"`
+	Alias       string `json:"alias"`
 }
 
 // GetWorkspaceId returns UpdateWorkspaceInput.WorkspaceId, and is useful for accessing the field via an interface.
@@ -2425,6 +2430,9 @@ func (v *UpdateWorkspaceInput) GetWorkspaceId() string { return v.WorkspaceId }
 
 // GetName returns UpdateWorkspaceInput.Name, and is useful for accessing the field via an interface.
 func (v *UpdateWorkspaceInput) GetName() string { return v.Name }
+
+// GetAlias returns UpdateWorkspaceInput.Alias, and is useful for accessing the field via an interface.
+func (v *UpdateWorkspaceInput) GetAlias() string { return v.Alias }
 
 // UpdateWorkspaceResponse is returned by UpdateWorkspace on success.
 type UpdateWorkspaceResponse struct {

--- a/account/accountusecase/accountproxy/workspace.go
+++ b/account/accountusecase/accountproxy/workspace.go
@@ -44,7 +44,7 @@ func (w *Workspace) FindByUser(ctx context.Context, userID accountdomain.UserID,
 	return ToWorkspaces(ws)
 }
 
-func (w *Workspace) Create(ctx context.Context, name string, userID accountdomain.UserID, op *accountusecase.Operator) (*workspace.Workspace, error) {
+func (w *Workspace) Create(ctx context.Context, name string, userID accountdomain.UserID, alias *string, op *accountusecase.Operator) (*workspace.Workspace, error) {
 	res, err := CreateWorkspace(ctx, w.gql, CreateWorkspaceInput{Name: name})
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func (w *Workspace) Create(ctx context.Context, name string, userID accountdomai
 	return ToWorkspace(res.CreateWorkspace.Workspace.FragmentWorkspace)
 }
 
-func (w *Workspace) Update(ctx context.Context, id workspace.ID, name string, op *accountusecase.Operator) (*workspace.Workspace, error) {
+func (w *Workspace) Update(ctx context.Context, id workspace.ID, name string, alias *string, op *accountusecase.Operator) (*workspace.Workspace, error) {
 	res, err := UpdateWorkspace(ctx, w.gql, UpdateWorkspaceInput{WorkspaceId: id.String(), Name: name})
 	if err != nil {
 		return nil, err

--- a/account/accountusecase/accountrepo/workspace.go
+++ b/account/accountusecase/accountrepo/workspace.go
@@ -19,6 +19,7 @@ type Workspace interface {
 	FindByIntegration(context.Context, workspace.IntegrationID) (workspace.List, error)
 	// FindByIntegrations finds workspace list based on integrations IDs
 	FindByIntegrations(context.Context, workspace.IntegrationIDList) (workspace.List, error)
+	CheckWorkspaceAliasUnique(context.Context, workspace.ID, string) error
 	Create(context.Context, *workspace.Workspace) error
 	Save(context.Context, *workspace.Workspace) error
 	SaveAll(context.Context, workspace.List) error

--- a/account/workspace.graphql
+++ b/account/workspace.graphql
@@ -1,6 +1,7 @@
 type Workspace implements Node {
     id: ID!
     name: String!
+    alias: String
     members: [WorkspaceMember!]!
     metadata: WorkspaceMetadata!
     personal: Boolean!
@@ -44,11 +45,13 @@ enum Role {
 
 input CreateWorkspaceInput {
     name: String!
+    alias: String
 }
 
 input UpdateWorkspaceInput {
     workspaceId: ID!
     name: String!
+    alias: String
 }
 
 input MemberInput {


### PR DESCRIPTION
# Add alias to the workspace API

## 1. The alias field is added to both workspace creation and update.
```diff
input CreateWorkspaceInput {
    name: String!
+    alias: String
}

input UpdateWorkspaceInput {
    workspaceId: ID!
    name: String!
+    alias: String
}
```
## 2.A uniqueness check will be performed when registering an alias.
```
CheckWorkspaceAliasUnique(context.Context, workspace.ID, string) error
```
## 3.If no alias is specified, it will be set to `w-{WorkspaceID}` by default.

