### PR TITLE
chore(util): update alias validation regex to allow uppercase and adjust length constraints

### DIFF
--- a/util/validator.go
+++ b/util/validator.go
@@ -5,16 +5,16 @@ import (
 	"strings"
 )
 
-var nameRegex = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-_@.]{0,61}[a-z0-9])?$`)
+var nameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{3,30}[a-zA-Z0-9]$`)
 
 // IsSafePathName
-// Compatible with Auth0's restricted character set (subset only: lowercase letters, numbers, hyphens, underscores, at (@), and dots (.))
+// Compatible with Auth0's restricted character set (subset only: lowercase letters, numbers, and hyphens)
 // Regex explanation:
 // ^                 // Start of string
 // [a-z0-9]          // First character must be a lowercase letter or digit
 // (?:               // Start non-capturing group:
 //
-//	[a-z0-9-]{1,61}  // Allow 1 to 61 lowercase letters, digits, or hyphens
+//	[a-z0-9-]{5,32}  // Allow 5 to 32 lowercase letters, digits, or hyphens
 //	[a-z0-9]         // Final character must be a lowercase letter or digit
 //
 // )?                // Group is optional to allow 1-character usernames
@@ -22,22 +22,14 @@ var nameRegex = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-_@.]{0,61}[a-z0-9])?$`)
 //
 // Notes:
 // - Prevents leading/trailing hyphens
-// - Does not allow special characters beyond a-z, 0-9, hyphens, underscores, at (@), and dots (.)
+// - Does not allow special characters beyond a-z, A-Z, 0-9, hyphens
 // - Safe for use in subdomains and URL path segments
 // - Does NOT allow consecutive hyphens; add extra logic in Go if needed
 func IsSafePathName(name string) bool {
-	name = strings.ToLower(name)
 	name = strings.TrimSpace(name)
-	chars := []string{"-", "_", ".", "@"}
+	char := "-"
 
-	for _, c := range chars {
-		if strings.Contains(name, c+c) {
-			return false
-		}
-	}
-
-	// Check if it's an email address (not allowed)
-	if strings.Contains(name, "@") && strings.Contains(name, ".") {
+	if strings.Contains(name, char+char) {
 		return false
 	}
 

--- a/util/validator_test.go
+++ b/util/validator_test.go
@@ -10,28 +10,41 @@ func TestIsSafePathName(t *testing.T) {
 		name     string
 		expected bool
 	}{
+		{"validname", true},
 		{"valid-name", true},
-		{"valid_name", true},
-		{"valid@name", true},
-		{"valid.name", true},
-		{"invalid--name", false},
-		{"invalid__name", false},
-		{"invalid..name", false},
-		{"invalid@@name", false},
-		{"invalid@name.com", false},
-		// Empty string test
-		{"", false},
+		{"valid123", true},
+		{"123valid", true},
+		{"a1b2c3", true},
+		{"ValidName", true},          // uppercase now allowed
+		{"VALIDNAME", true},          // uppercase now allowed
+		{"Valid-Name", true},         // mixed case now allowed
+		{"invalid_name", false},      // underscores not allowed
+		{"invalid@name", false},      // @ not allowed
+		{"invalid.name", false},      // dots not allowed
+		{"invalid@test.name", false}, // email not allowed
+		{"invalid--name", false},     // consecutive hyphens not allowed
+		{"-invalid", false},          // leading hyphen not allowed
+		{"invalid-", false},          // trailing hyphen not allowed
+		{"", false},                  // empty string
 		// Whitespace trimming tests
-		{" validname", true},
-		{"validname ", true},
-		{" validname ", true},
-		// Case insensitivity tests
-		{"ValidName", true},
-		{"VALIDNAME", true},
-		// Length boundary tests
-		{"a", true}, // 1 character - minimum
-		{"a" + strings.Repeat("b", 61) + "c", true},  // 63 characters - maximum
-		{"a" + strings.Repeat("b", 62) + "c", false}, // 64 characters - exceeds maximum
+		{" validname", true},  // leading space trimmed
+		{"validname ", true},  // trailing space trimmed
+		{" validname ", true}, // both spaces trimmed
+		{" ValidName ", true}, // mixed case with spaces trimmed
+		// Length boundary tests - now only 5-32 characters allowed
+		{"a", false}, // 1 character - too short
+		{"A", false}, // 1 uppercase character - too short
+		{"1", false}, // 1 digit - too short
+		{"a" + strings.Repeat("b", 5) + "c", true},   // 7 characters - valid range
+		{"A" + strings.Repeat("B", 5) + "C", true},   // 7 uppercase characters - valid range
+		{"a" + strings.Repeat("b", 30) + "c", true},  // 32 characters - maximum valid
+		{"a" + strings.Repeat("b", 31) + "c", false}, // 33 characters - too long
+		{"ab", false},     // 2 characters - too short
+		{"abc", false},    // 3 characters - too short
+		{"abcd", false},   // 4 characters - too short
+		{"abcde", true},   // 5 characters - minimum valid
+		{"abcdef", true},  // 6 characters - valid
+		{"abcdefg", true}, // 7 characters - valid
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pull request updates the username validation logic to enforce stricter and more consistent naming rules, and revises the associated tests to match the new requirements. The main focus is on limiting allowed characters, enforcing case sensitivity, and narrowing the valid length range for usernames.

**Validation rule changes:**

* The `nameRegex` in `util/validator.go` now only allows alphanumeric characters (both uppercase and lowercase) and hyphens, with usernames required to be between 5 and 32 characters long, start and end with an alphanumeric character, and not contain consecutive hyphens. Special characters like underscores, dots, and @ are no longer permitted.
* The logic for checking consecutive invalid characters is simplified to only check for consecutive hyphens.

**Test updates:**

* The test cases in `util/validator_test.go` are updated to reflect the new validation rules: tests for previously valid usernames with underscores, dots, or @ are now expected to fail, and tests for mixed or uppercase names are now expected to pass. The valid length range is tested thoroughly, with new cases for minimum and maximum length boundaries.