### PR TITLE
fix(account): generate random username in OIDC signup

### DIFF
--- a/account/accountusecase/accountinteractor/user_signup.go
+++ b/account/accountusecase/accountinteractor/user_signup.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	textTmpl "text/template"
 
+	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 	"github.com/reearth/reearthx/account/accountusecase/accountinterfaces"
@@ -128,9 +129,6 @@ func (i *User) SignupOIDC(ctx context.Context, param accountinterfaces.SignupOID
 		if name == "" {
 			name = ui.Name
 		}
-		if name == "" {
-			name = ui.Email
-		}
 	}
 
 	eu, err := i.repos.User.FindByEmail(ctx, param.Email)
@@ -147,6 +145,11 @@ func (i *User) SignupOIDC(ctx context.Context, param accountinterfaces.SignupOID
 	}
 	if eu != nil {
 		return nil, accountrepo.ErrDuplicatedUser
+	}
+
+	// Generate random name if empty
+	if name == "" {
+		name = "user-" + strings.ToLower(accountdomain.NewUserID().String())
 	}
 
 	// Initialize user and ws


### PR DESCRIPTION
## Summary

- Removed email fallback for username in OIDC signup flow
- Added random username generation using ULID format when name is not provided by OIDC provider

## Changes

### OIDC Signup improvements
- Removed lines that assigned email to username when name was empty
- Added logic to generate random username after duplicate checks
- Username format: `user-{lowercase-ulid}` (e.g., `user-01hqkf3v8m2qn7y6x9z0abc123`)

## Behavior

**Before:**
- If OIDC provider didn't provide `nickname` or `name`, the user's email was used as username

**After:**
- If OIDC provider doesn't provide `nickname` or `name`, a random username is generated
- Improves privacy by not exposing email addresses as usernames
- Prevents username conflicts with ULID-based generation

## Test plan

- [x] Test OIDC signup with provider that provides nickname
- [x] Test OIDC signup with provider that provides name but no nickname
- [x] Test OIDC signup with provider that provides neither name nor nickname (should generate random username)
- [x] Verify generated usernames are lowercase and follow expected format
- [x] All existing tests pass

## Related PRs

- #127 - Username email validation (separated concern)