### PR TITLE
chore(go): upgrade Go to 1.26.2 and golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
           args: --timeout=10m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: set up
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21
+          go-version: 1.26
       - name: checkout
         uses: actions/checkout@v3
       - name: cache
@@ -32,7 +32,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.64.8
+          version: v2.11.4
           args: --timeout=10m
       - name: test
         run: go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic -timeout 10m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.4
           args: --timeout=10m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v2.11.4
           args: --timeout=10m

--- a/account/accountinfrastructure/accountmongo/workspace.go
+++ b/account/accountinfrastructure/accountmongo/workspace.go
@@ -47,7 +47,7 @@ func (r *Workspace) Filtered(f accountrepo.WorkspaceFilter) accountrepo.Workspac
 
 func (r *Workspace) FindByUser(ctx context.Context, id user.ID) (workspace.List, error) {
 	return r.find(ctx, bson.M{
-		"members." + strings.Replace(id.String(), ".", "", -1): bson.M{
+		"members." + strings.ReplaceAll(id.String(), ".", ""): bson.M{
 			"$exists": true,
 		},
 	})
@@ -55,7 +55,7 @@ func (r *Workspace) FindByUser(ctx context.Context, id user.ID) (workspace.List,
 
 func (r *Workspace) FindByUserWithPagination(ctx context.Context, id user.ID, pagination *usecasex.Pagination) (workspace.List, *usecasex.PageInfo, error) {
 	filter := bson.M{
-		"members." + strings.Replace(id.String(), ".", "", -1): bson.M{
+		"members." + strings.ReplaceAll(id.String(), ".", ""): bson.M{
 			"$exists": true,
 		},
 	}
@@ -65,7 +65,7 @@ func (r *Workspace) FindByUserWithPagination(ctx context.Context, id user.ID, pa
 
 func (r *Workspace) FindByIntegration(ctx context.Context, id workspace.IntegrationID) (workspace.List, error) {
 	return r.find(ctx, bson.M{
-		"integrations." + strings.Replace(id.String(), ".", "", -1): bson.M{
+		"integrations." + strings.ReplaceAll(id.String(), ".", ""): bson.M{
 			"$exists": true,
 		},
 	})
@@ -80,7 +80,7 @@ func (r *Workspace) FindByIntegrations(ctx context.Context, integrationIDs works
 	orConditions := make([]bson.M, 0)
 	for _, id := range integrationIDs {
 		orConditions = append(orConditions, bson.M{
-			"integrations." + strings.Replace(id.String(), ".", "", -1): bson.M{
+			"integrations." + strings.ReplaceAll(id.String(), ".", ""): bson.M{
 				"$exists": true,
 			},
 		})

--- a/appx/tracer.go
+++ b/appx/tracer.go
@@ -26,9 +26,10 @@ type TracerConfig struct {
 }
 
 func InitTracer(ctx context.Context, conf *TracerConfig) io.Closer {
-	if conf.Tracer == TRACER_GCP {
+	switch conf.Tracer {
+	case TRACER_GCP:
 		initGCPTracer(ctx, conf)
-	} else if conf.Tracer == TRACER_JAEGER {
+	case TRACER_JAEGER:
 		return initJaegerTracer(conf)
 	}
 	return nil

--- a/appx/tracer_test.go
+++ b/appx/tracer_test.go
@@ -53,10 +53,11 @@ func TestInitTracer(t *testing.T) {
 
 	// Create a test wrapper for InitTracer that uses the function variables
 	testInitTracer := func(ctx context.Context, conf *TracerConfig) io.Closer {
-		if conf.Tracer == TRACER_GCP {
+		switch conf.Tracer {
+		case TRACER_GCP:
 			testInitGCPTracer(ctx, conf)
 			return nil
-		} else if conf.Tracer == TRACER_JAEGER {
+		case TRACER_JAEGER:
 			return testInitJaegerTracer(conf)
 		}
 		return nil

--- a/authserver/endpoint.go
+++ b/authserver/endpoint.go
@@ -45,9 +45,9 @@ func (c *EndpointConfig) normalize() {
 	}
 
 	if c.Dev {
-		os.Setenv(op.OidcDevMode, "true")
+		_ = os.Setenv(op.OidcDevMode, "true")
 	} else {
-		os.Unsetenv(op.OidcDevMode)
+		_ = os.Unsetenv(op.OidcDevMode)
 	}
 }
 

--- a/authserver/key.go
+++ b/authserver/key.go
@@ -73,7 +73,7 @@ func generateCert(name pkix.Name) (keyPem, certPem []byte, err error) {
 
 	certBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, key.Public(), key)
 	if err != nil {
-		err = fmt.Errorf("failed to create the cert: %w\n", err)
+		err = fmt.Errorf("failed to create the cert: %w", err)
 	}
 
 	certPem = pem.EncodeToMemory(&pem.Block{

--- a/authserver/key.go
+++ b/authserver/key.go
@@ -20,7 +20,7 @@ func initKeys(keyBytes, certBytes []byte) (*rsa.PrivateKey, *jose.SigningKey, *j
 	}
 	key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to parse the private key bytes: %w\n", err)
+		return nil, nil, nil, fmt.Errorf("failed to parse the private key bytes: %w", err)
 	}
 
 	var certActualBytes []byte
@@ -34,7 +34,7 @@ func initKeys(keyBytes, certBytes []byte) (*rsa.PrivateKey, *jose.SigningKey, *j
 	var cert *x509.Certificate
 	cert, err = x509.ParseCertificate(certActualBytes)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to parse the cert bytes: %w\n", err)
+		return nil, nil, nil, fmt.Errorf("failed to parse the cert bytes: %w", err)
 	}
 
 	keyID := "RE01"
@@ -53,7 +53,7 @@ func initKeys(keyBytes, certBytes []byte) (*rsa.PrivateKey, *jose.SigningKey, *j
 func generateCert(name pkix.Name) (keyPem, certPem []byte, err error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		err = fmt.Errorf("failed to generate key: %w\n", err)
+		err = fmt.Errorf("failed to generate key: %w", err)
 		return
 	}
 

--- a/authserver/storage.go
+++ b/authserver/storage.go
@@ -107,14 +107,14 @@ func NewStorage(ctx context.Context, cfg StorageConfig) (op.Storage, error) {
 		}
 
 		if err := cfg.ConfigRepo.Save(ctx, c); err != nil {
-			return nil, fmt.Errorf("could not save raw cert: %w\n", err)
+			return nil, fmt.Errorf("could not save raw cert: %w", err)
 		}
 		log.Infoc(ctx, "auth: init a new private key and certificate")
 	}
 
 	key, sigKey, keySet, err := initKeys(keyBytes, certBytes)
 	if err != nil {
-		return nil, fmt.Errorf("could not init keys: %w\n", err)
+		return nil, fmt.Errorf("could not init keys: %w", err)
 	}
 
 	return &Storage{

--- a/authserver/storage.go
+++ b/authserver/storage.go
@@ -84,7 +84,7 @@ func NewStorage(ctx context.Context, cfg StorageConfig) (op.Storage, error) {
 	}
 	c, err := cfg.ConfigRepo.Load(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("could not load auth config: %w\n", err)
+		return nil, fmt.Errorf("could not load auth config: %w", err)
 	}
 	defer func() {
 		if err := cfg.ConfigRepo.Unlock(ctx); err != nil {
@@ -99,7 +99,7 @@ func NewStorage(ctx context.Context, cfg StorageConfig) (op.Storage, error) {
 	} else {
 		keyBytes, certBytes, err = generateCert(name)
 		if err != nil {
-			return nil, fmt.Errorf("could not generate raw cert: %w\n", err)
+			return nil, fmt.Errorf("could not generate raw cert: %w", err)
 		}
 		c = &Config{
 			Key:  string(keyBytes),

--- a/cerbos/client/check.go
+++ b/cerbos/client/check.go
@@ -109,7 +109,7 @@ func (c *Client) executeRequest(req *http.Request) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to send request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("server returned non-OK status: %d", resp.StatusCode)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reearth/reearthx
 
-go 1.24.2
+go 1.26.2
 
 require (
 	github.com/99designs/gqlgen v0.17.73

--- a/mailer/common.go
+++ b/mailer/common.go
@@ -50,13 +50,14 @@ type SESConfig struct {
 
 func New(ctx context.Context, conf *Config) (m Mailer) {
 	mt := conf.Mailer
-	if mt == "sendgrid" {
+	switch mt {
+	case "sendgrid":
 		m = NewSendGrid(conf.SendGrid.Name, conf.SendGrid.Email, conf.SendGrid.API)
-	} else if mt == "smtp" {
+	case "smtp":
 		m = NewSMTP(conf.SMTP.Host, conf.SMTP.Port, conf.SMTP.SMTPUsername, conf.SMTP.Email, conf.SMTP.Password)
-	} else if mt == "ses" {
+	case "ses":
 		m = NewSES(ctx, conf.SES.Name, conf.SES.Email)
-	} else {
+	default:
 		mt = "logger"
 		m = NewLogger()
 	}
@@ -123,9 +124,9 @@ func (m *message) encodeContent() (string, error) {
 
 func (m *message) encodeMessage() ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
-	buf.WriteString(fmt.Sprintf("Subject: %s\n", m.subject))
-	buf.WriteString(fmt.Sprintf("From: %s\n", m.from))
-	buf.WriteString(fmt.Sprintf("To: %s\n", strings.Join(m.to, ",")))
+	fmt.Fprintf(buf, "Subject: %s\n", m.subject)
+	fmt.Fprintf(buf, "From: %s\n", m.from)
+	fmt.Fprintf(buf, "To: %s\n", strings.Join(m.to, ","))
 	content, err := m.encodeContent()
 	if err != nil {
 		return nil, err

--- a/rerror/error.go
+++ b/rerror/error.go
@@ -194,10 +194,7 @@ func Is(err error, label error) bool {
 	}
 	e := err
 	var target *Error
-	for {
-		if !errors.As(e, &target) {
-			break
-		}
+	for errors.As(e, &target) {
 		if target.Label == label {
 			return true
 		}

--- a/rerror/stack.go
+++ b/rerror/stack.go
@@ -30,7 +30,7 @@ func PretifyStack(r io.Reader, w io.Writer) {
 	srcLen := 0
 	pkgLen := 0
 	for _, bucket := range buckets {
-		for _, line := range bucket.Signature.Stack.Calls {
+		for _, line := range bucket.Stack.Calls {
 			if l := len(fmt.Sprintf("%s:%d", line.SrcName, line.Line)); l > srcLen {
 				srcLen = l
 			}
@@ -53,11 +53,11 @@ func PretifyStack(r io.Reader, w io.Writer) {
 		if len(bucket.CreatedBy.Calls) != 0 {
 			extra += fmt.Sprintf(" [Created by %s.%s @ %s:%d]", bucket.CreatedBy.Calls[0].Func.DirName, bucket.CreatedBy.Calls[0].Func.Name, bucket.CreatedBy.Calls[0].SrcName, bucket.CreatedBy.Calls[0].Line)
 		}
-		fmt.Fprintf(w, "%d: %s%s\n", len(bucket.IDs), bucket.State, extra)
+		_, _ = fmt.Fprintf(w, "%d: %s%s\n", len(bucket.IDs), bucket.State, extra)
 
 		// Print the stack lines.
 		for _, line := range bucket.Stack.Calls {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"    %-*s %-*s %s(%s)\n",
 				pkgLen, line.Func.DirName, srcLen,

--- a/tools/i18nextractor/command.go
+++ b/tools/i18nextractor/command.go
@@ -114,7 +114,7 @@ func (c *Config) execute() error {
 		}
 	}
 
-	os.Stderr.WriteString("done\n")
+	_, _ = fmt.Fprint(os.Stderr,"done\n")
 
 	if update && c.FailOnUpdate {
 		return ErrUpdate
@@ -123,11 +123,11 @@ func (c *Config) execute() error {
 }
 
 func (c *Config) mergeFile(path, format string, data any) (bool, error) {
-	os.Stderr.WriteString(fmt.Sprintf("writing messages to %s", path))
+	_, _ = fmt.Fprint(os.Stderr,fmt.Sprintf("writing messages to %s", path))
 
 	f, err := c.Output.Open(path)
 	if err != nil && !errors.Is(err, afero.ErrFileNotFound) {
-		os.Stderr.WriteString("\n")
+		_, _ = fmt.Fprint(os.Stderr,"\n")
 		return false, err
 	}
 
@@ -137,29 +137,29 @@ func (c *Config) mergeFile(path, format string, data any) (bool, error) {
 			_ = f.Close()
 		}()
 		if err := unmarshal(f, &a, format); err != nil {
-			os.Stderr.WriteString("\n")
+			_, _ = fmt.Fprint(os.Stderr,"\n")
 			return false, err
 		}
 	}
 
 	merged := merge(a, data)
 	if merged == nil {
-		os.Stderr.WriteString(" ... no updates\n")
+		_, _ = fmt.Fprint(os.Stderr," ... no updates\n")
 		return false, nil
 	}
 
 	o, err := marshal(merged, format)
 	if err != nil {
-		os.Stderr.WriteString("\n")
+		_, _ = fmt.Fprint(os.Stderr,"\n")
 		return false, err
 	}
 
 	if err := afero.WriteFile(c.Output, path, o, 0644); err != nil {
-		os.Stderr.WriteString("\n")
+		_, _ = fmt.Fprint(os.Stderr,"\n")
 		return false, err
 	}
 
-	os.Stderr.WriteString(" ... done\n")
+	_, _ = fmt.Fprint(os.Stderr," ... done\n")
 	return true, nil
 }
 

--- a/tools/i18nextractor/command.go
+++ b/tools/i18nextractor/command.go
@@ -114,7 +114,7 @@ func (c *Config) execute() error {
 		}
 	}
 
-	_, _ = fmt.Fprint(os.Stderr,"done\n")
+	_, _ = fmt.Fprint(os.Stderr, "done\n")
 
 	if update && c.FailOnUpdate {
 		return ErrUpdate
@@ -123,11 +123,11 @@ func (c *Config) execute() error {
 }
 
 func (c *Config) mergeFile(path, format string, data any) (bool, error) {
-	_, _ = fmt.Fprint(os.Stderr,fmt.Sprintf("writing messages to %s", path))
+	_, _ = fmt.Fprintf(os.Stderr, "writing messages to %s", path)
 
 	f, err := c.Output.Open(path)
 	if err != nil && !errors.Is(err, afero.ErrFileNotFound) {
-		_, _ = fmt.Fprint(os.Stderr,"\n")
+		_, _ = fmt.Fprint(os.Stderr, "\n")
 		return false, err
 	}
 
@@ -137,29 +137,29 @@ func (c *Config) mergeFile(path, format string, data any) (bool, error) {
 			_ = f.Close()
 		}()
 		if err := unmarshal(f, &a, format); err != nil {
-			_, _ = fmt.Fprint(os.Stderr,"\n")
+			_, _ = fmt.Fprint(os.Stderr, "\n")
 			return false, err
 		}
 	}
 
 	merged := merge(a, data)
 	if merged == nil {
-		_, _ = fmt.Fprint(os.Stderr," ... no updates\n")
+		_, _ = fmt.Fprint(os.Stderr, " ... no updates\n")
 		return false, nil
 	}
 
 	o, err := marshal(merged, format)
 	if err != nil {
-		_, _ = fmt.Fprint(os.Stderr,"\n")
+		_, _ = fmt.Fprint(os.Stderr, "\n")
 		return false, err
 	}
 
 	if err := afero.WriteFile(c.Output, path, o, 0644); err != nil {
-		_, _ = fmt.Fprint(os.Stderr,"\n")
+		_, _ = fmt.Fprint(os.Stderr, "\n")
 		return false, err
 	}
 
-	_, _ = fmt.Fprint(os.Stderr," ... done\n")
+	_, _ = fmt.Fprint(os.Stderr, " ... done\n")
 	return true, nil
 }
 

--- a/tools/i18nextractor/command.go
+++ b/tools/i18nextractor/command.go
@@ -80,7 +80,7 @@ func (c *Config) execute() error {
 
 		l := len(msgs)
 		if l > 0 {
-			os.Stderr.WriteString(fmt.Sprintf("%s ... %d messages\n", path, l))
+			_, _ = fmt.Fprintf(os.Stderr, "%s ... %d messages\n", path, l)
 		}
 
 		return nil
@@ -89,9 +89,9 @@ func (c *Config) execute() error {
 	}
 
 	if len(messages) > 0 {
-		os.Stderr.WriteString("\n")
+		_, _ = fmt.Fprint(os.Stderr, "\n")
 	}
-	os.Stderr.WriteString(fmt.Sprintf("%d messages found\n", len(messages)))
+	_, _ = fmt.Fprintf(os.Stderr, "%d messages found\n", len(messages))
 
 	messageTemplates := map[string]*i18n.MessageTemplate{}
 	for _, m := range messages {

--- a/tools/main.go
+++ b/tools/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("%s\n", err))
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 }

--- a/usecasex/migration/client.go
+++ b/usecasex/migration/client.go
@@ -56,7 +56,7 @@ func (c Client[C]) Migrate(ctx context.Context) (err error) {
 
 	current, err := c.config.Current(ctx)
 	if err != nil {
-		return fmt.Errorf("Failed to load config: %w", rerror.UnwrapErrInternal(err))
+		return fmt.Errorf("failed to load config: %w", rerror.UnwrapErrInternal(err))
 	}
 
 	nextMigrations := nextMigration(lo.Keys(c.migrations), current)
@@ -74,7 +74,7 @@ func (c Client[C]) Migrate(ctx context.Context) (err error) {
 
 			return c.config.Save(ctx, m)
 		}); err != nil {
-			return fmt.Errorf("Failed to exec migration %d: %w", m, rerror.UnwrapErrInternalOr(err))
+			return fmt.Errorf("failed to exec migration %d: %w", m, rerror.UnwrapErrInternalOr(err))
 		}
 	}
 

--- a/usecasex/migration/client_test.go
+++ b/usecasex/migration/client_test.go
@@ -60,7 +60,7 @@ func TestClientError(t *testing.T) {
 	}
 	cl := NewClient(c, r, m, 0)
 
-	assert.EqualError(t, cl.Migrate(ctx), "Failed to exec migration 30: ERR!")
+	assert.EqualError(t, cl.Migrate(ctx), "failed to exec migration 30: ERR!")
 	assert.Equal(t, 1, r.beginCalls)
 	assert.Equal(t, 1, r.endCalls)
 	assert.Equal(t, 1, r.currentCalls)

--- a/usecasex/transaction.go
+++ b/usecasex/transaction.go
@@ -12,8 +12,8 @@ import (
 const IDErrTransaction = "transaction error"
 
 var (
-	ErrTransaction    = rerror.WrapE(&i18n.Message{ID: IDErrTransaction}, rawErrTransaction)
-	rawErrTransaction = errors.New("transaction conflicted")
+	ErrTransaction    = rerror.WrapE(&i18n.Message{ID: IDErrTransaction}, errTransactionConflicted)
+	errTransactionConflicted = errors.New("transaction conflicted")
 )
 
 type Transaction interface {
@@ -89,10 +89,7 @@ func DoTransaction(ctx context.Context, t Transaction, retry int, fn func(ctx co
 	}()
 
 	r := 0
-	for {
-		if r > 0 && (retry <= 0 || r > retry) {
-			break
-		}
+	for r == 0 || (retry > 0 && r <= retry) {
 		if err = fn(ctx2); err != nil {
 			if !errors.Is(err, ErrTransaction) {
 				break


### PR DESCRIPTION
## Summary

- Bump Go version from 1.24.2 to 1.26.2 in \`go.mod\` and CI workflow
- Upgrade \`golangci-lint\` from \`v1.64.8\` to \`v2.11.4\` and \`golangci-lint-action\` from \`v3\` to \`v9\` (required for v2.x support)
- Fix all lint issues surfaced by golangci-lint v2:
  - **errcheck**: handle return values of \`os.Setenv\`, \`os.Unsetenv\`, \`resp.Body.Close\`, \`fmt.Fprintf\`, \`os.Stderr.WriteString\`
  - **staticcheck**: \`strings.Replace\` → \`strings.ReplaceAll\`, \`if/else\` → \`switch\` (tracer, mailer), strip trailing \`\\n\` from error strings, lowercase error messages, use \`fmt.Fprintf\` over \`WriteString(fmt.Sprintf(...))\`, lift loop conditions, remove redundant embedded field selector, rename \`rawErrTransaction\` to \`errTransactionConflicted\`
- Update test expectation to match lowercased error message in migration client
- Run \`go mod tidy\` to sync \`go.sum\` with updated toolchain

## Test plan

- [x] CI passes with the new Go and linter versions
- [x] All tests pass locally