### PR TITLE
fix(usecasex,mongox): fix DoTransaction to use fresh session per retry

### DIFF
--- a/appx/server_test.go
+++ b/appx/server_test.go
@@ -60,7 +60,7 @@ func TestStartServer_ServesAndShutsDown(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status %d", resp.StatusCode)
 		}
@@ -115,7 +115,7 @@ func TestStartServer_H2C(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(resp.Body)
 		if string(body) != "HTTP/2.0" {
 			return fmt.Errorf("proto=%q, want HTTP/2.0", body)

--- a/mongox/tx.go
+++ b/mongox/tx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
 // Tx implements usecasex.Tx, but note that it's not goroutine-safe.
@@ -38,8 +39,16 @@ func (t *Tx) End(ctx context.Context) error {
 	}
 
 	if t.commit {
-		if err := t.session.CommitTransaction(ctx); err != nil {
-			return err
+		// Retry commit on UnknownTransactionCommitResult — the transaction may
+		// have committed but the driver didn't receive confirmation.
+		for {
+			err := t.session.CommitTransaction(ctx)
+			if err == nil {
+				break
+			}
+			if !errorHasLabel(err, driver.UnknownTransactionCommitResult) {
+				return err
+			}
 		}
 	} else if err := t.session.AbortTransaction(ctx); err != nil {
 		return err

--- a/usecasex/transaction.go
+++ b/usecasex/transaction.go
@@ -3,6 +3,7 @@ package usecasex
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/reearth/reearthx/i18n"
 	"github.com/reearth/reearthx/rerror"
@@ -71,35 +72,42 @@ func (t *NopTx) Context() context.Context {
 	return t.ctx
 }
 
-func DoTransaction(ctx context.Context, t Transaction, retry int, fn func(ctx context.Context) error) (err error) {
+// DoTransaction runs fn inside a transaction, retrying up to retry additional
+// times on TransientTransactionError (e.g. MongoDB WriteConflict). Each retry
+// starts a fresh Begin so the underlying driver can renegotiate locks cleanly,
+// which is required for MongoDB multi-document transactions. A linear backoff
+// of 50ms × attempt is applied between retries.
+func DoTransaction(ctx context.Context, t Transaction, retry int, fn func(ctx context.Context) error) error {
 	if t == nil {
 		return fn(ctx)
 	}
 
-	tx, err := t.Begin(ctx)
-	if err != nil {
-		return err
-	}
-
-	ctx2 := tx.Context()
-	defer func() {
-		if err2 := tx.End(ctx2); err2 != nil && err == nil {
-			err = err2
+	var lastErr error
+	for attempt := 0; attempt == 0 || (retry > 0 && attempt <= retry); attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 50 * time.Millisecond)
 		}
-	}()
 
-	r := 0
-	for r == 0 || (retry > 0 && r <= retry) {
-		if err = fn(ctx2); err != nil {
-			if !errors.Is(err, ErrTransaction) {
-				break
-			}
-		} else {
+		tx, err := t.Begin(ctx)
+		if err != nil {
+			return err
+		}
+
+		txCtx := tx.Context()
+		lastErr = fn(txCtx)
+		if lastErr == nil {
 			tx.Commit()
-			break
 		}
-		r++
+		if endErr := tx.End(txCtx); endErr != nil && lastErr == nil {
+			lastErr = endErr
+		}
+		if lastErr == nil {
+			return nil
+		}
+		if !errors.Is(lastErr, ErrTransaction) {
+			return lastErr
+		}
 	}
 
-	return err
+	return lastErr
 }


### PR DESCRIPTION
## Summary

- **`usecasex/transaction.go`**: `DoTransaction` previously reused the same MongoDB session across all retry attempts. After a `TransientTransactionError` (e.g. `WriteConflict`), the session is in an aborted state and cannot be reused — so retries always failed, making the loop a no-op. Fixed to call `Begin()` fresh for each attempt, and added a linear backoff (50ms × attempt) between retries to reduce thundering herd.
- **`mongox/tx.go`**: `End()` now retries `CommitTransaction` on `UnknownTransactionCommitResult` — the "commit may or may not have been applied" error — matching the retry pattern recommended in the [MongoDB Go driver docs](https://www.mongodb.com/docs/manual/core/transactions-in-applications/).

## Background

This was discovered while fixing a `WriteConflict` burst in `reearth-visualizer` where concurrent `publishProject` / `publishStory` calls conflicted because GCS uploads were running inside an open transaction. The structural fix (moving I/O outside the transaction) is in the visualizer, but the broken retry logic in `DoTransaction` meant that even with retries configured, conflicts were never actually recovered from.

All existing callers pass `retry=2` and wrap pure DB operations — no behaviour change for the happy path. On conflict, they now get working retries instead of guaranteed second failures.

## Test plan

- [ ] Existing `usecasex` and `mongox` unit tests pass
- [ ] Verify against a local MongoDB replica set that concurrent writes retry and succeed rather than failing permanently