### PR TITLE
fix(cerbos): client timeout + drop debug logging on permission check

### DIFF
--- a/appx/server_test.go
+++ b/appx/server_test.go
@@ -60,7 +60,7 @@ func TestStartServer_ServesAndShutsDown(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status %d", resp.StatusCode)
 		}
@@ -115,7 +115,7 @@ func TestStartServer_H2C(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(resp.Body)
 		if string(body) != "HTTP/2.0" {
 			return fmt.Errorf("proto=%q, want HTTP/2.0", body)

--- a/cerbos/client/check.go
+++ b/cerbos/client/check.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+	"time"
 
 	"github.com/reearth/reearthx/appx"
 )
+
+const defaultRequestTimeout = 30 * time.Second
 
 const (
 	checkPermissionQuery = `
@@ -29,7 +31,7 @@ type Client struct {
 
 func NewClient(dashboardURL string) *Client {
 	return &Client{
-		httpClient:   &http.Client{},
+		httpClient:   &http.Client{Timeout: defaultRequestTimeout},
 		dashboardURL: dashboardURL,
 	}
 }
@@ -114,15 +116,6 @@ func (c *Client) executeRequest(req *http.Request) (bool, error) {
 	if resp.StatusCode != http.StatusOK {
 		return false, fmt.Errorf("server returned non-OK status: %d", resp.StatusCode)
 	}
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return false, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	fmt.Printf("Response body: %s\n", string(bodyBytes))
-
-	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	var response CheckPermissionResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {


### PR DESCRIPTION
## Findings addressed

- **[REL-03] [HIGH] Cerbos permission client has no timeout** — `NewClient` built `&http.Client{}` (zero/no deadline). `CheckPermission` runs on the request-path authorization check, so a slow/stalled Cerbos dashboard would block every authorized request indefinitely; context timeout was the only guard and callers may not set one. A single dependency stall could cascade into a total authorization outage.
- **[SCA-05] [MEDIUM] Permission check buffers full response and Printfs it on every call** — `executeRequest` did `io.ReadAll(resp.Body)` + `fmt.Printf("Response body: %s\n", ...)` on every check, then re-wrapped the bytes for decoding, on the auth hot path of every authorized request.

## Changes

- `NewClient` now uses `&http.Client{Timeout: 30 * time.Second}`.
- `executeRequest` decodes directly from `resp.Body` — removed the `io.ReadAll`, the `fmt.Printf`, and the `io.NopCloser` re-buffering. Dropped the now-unused `io` import.

No behavior change to the permission result; only the timeout guard and removal of the per-request log/buffering.

## Verification

- `go build ./cerbos/...` ✓
- `go vet ./cerbos/...` ✓