### PR TITLE
fix(mongox): release MongoDB session when StartTransaction fails

### DIFF
--- a/appx/server_test.go
+++ b/appx/server_test.go
@@ -60,7 +60,7 @@ func TestStartServer_ServesAndShutsDown(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status %d", resp.StatusCode)
 		}
@@ -115,7 +115,7 @@ func TestStartServer_H2C(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(resp.Body)
 		if string(body) != "HTTP/2.0" {
 			return fmt.Errorf("proto=%q, want HTTP/2.0", body)

--- a/mongox/transaction.go
+++ b/mongox/transaction.go
@@ -29,6 +29,7 @@ func (t *Transaction) Begin(ctx context.Context) (usecasex.Tx, error) {
 	}
 
 	if err := s.StartTransaction(options.Transaction()); err != nil {
+		s.EndSession(ctx)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Finding addressed

- **[REL-04] [HIGH] MongoDB session leaked when StartTransaction fails** — `Begin` starts a session, then calls `s.StartTransaction`. On failure it returned without `s.EndSession(ctx)`, leaking the session. Transient Mongo errors (failover, primary step-down, config-server hiccup) make every `StartTransaction` attempt leak a session into the pool; repeated leaks during an incident exhaust the driver's session/connection limit, converting a transient blip into a hard, self-sustaining outage.

## Change

In `Transaction.Begin`, the `StartTransaction` error path now calls `s.EndSession(ctx)` before returning the error.

- Success path is unchanged: `newTx` takes ownership of the session and `Tx.End` calls `EndSession`.
- The earlier `StartSession` failure path needs no cleanup (no session exists yet).

## Verification

- `go build ./mongox/...` ✓
- `go vet ./mongox/...` ✓
- `go test ./mongox/...` ✓ (70 passed)