### PR TITLE
fix(appx): graceful drain — decouple request BaseContext from SIGTERM

### DIFF
--- a/appx/server.go
+++ b/appx/server.go
@@ -109,7 +109,13 @@ func StartServer(ctx context.Context, cfg ServerConfig) error {
 		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
 		IdleTimeout:       cfg.IdleTimeout,
 		MaxHeaderBytes:    cfg.MaxHeaderBytes,
-		BaseContext:       func(net.Listener) context.Context { return ctx },
+		// BaseContext must NOT derive from ctx: ctx is the shutdown signal
+		// context, and deriving request contexts from it would cancel every
+		// in-flight request the instant SIGTERM fires, defeating graceful
+		// drain. srv.Shutdown alone stops new connections and drains in-flight
+		// requests. Per-request cancellation comes from the connection
+		// closing (e.g. Cloud Run's request timeout), not from this context.
+		BaseContext: func(net.Listener) context.Context { return context.Background() },
 	}
 
 	errCh := make(chan error, 1)

--- a/appx/server_test.go
+++ b/appx/server_test.go
@@ -60,7 +60,7 @@ func TestStartServer_ServesAndShutsDown(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status %d", resp.StatusCode)
 		}
@@ -115,7 +115,7 @@ func TestStartServer_H2C(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(resp.Body)
 		if string(body) != "HTTP/2.0" {
 			return fmt.Errorf("proto=%q, want HTTP/2.0", body)


### PR DESCRIPTION
## Finding addressed

- **[REL-05] [HIGH] BaseContext tied to signal ctx cancels in-flight requests on SIGTERM** — `BaseContext` returned the caller's `ctx` (typically `signal.NotifyContext(SIGTERM)`), so every request context was a child of the shutdown signal. On any SIGTERM (routine Cloud Run revision replacement, k8s rolling deploy, autoscale-down) `srv.Shutdown` is entered to drain, but every already-accepted request simultaneously observed `ctx.Done()` and aborted — downstream ctx-honoring DB/HTTP calls returned `context.Canceled`, multi-step writes aborted between steps, handlers returned 5xx. This produced bursts of failed requests and partial writes on every deploy, the opposite of the intended graceful drain.

## Change

`BaseContext` now returns `context.Background()` instead of the signal context, with an explanatory comment. Graceful shutdown relies on `srv.Shutdown` alone to stop accepting new connections and drain in-flight requests; per-request cancellation still comes from the connection closing (platform request timeout), not from the shutdown signal.

The shutdown trigger — waiting on `ctx.Done()` then calling `srv.Shutdown(shutdownCtx)` — is unchanged. The old `BaseContext` captured no per-request values, so `context.Background()` is a safe drop-in.

## Verification

- `go build ./appx/...` ✓
- `go vet ./appx/...` ✓
- `go test ./appx/...` ✓ (21 passed)