### PR TITLE
fix(account): timeout + close response body on OIDC HTTP calls

### DIFF
--- a/account/accountusecase/accountinteractor/user_signup.go
+++ b/account/accountusecase/accountinteractor/user_signup.go
@@ -297,7 +297,7 @@ func getOpenIDConfiguration(ctx context.Context, iss string) (c OpenIDConfigurat
 		err = err2
 		return
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		err = rerror.NewE(i18n.T("could not get user info"))
@@ -329,7 +329,7 @@ func getUserInfo(ctx context.Context, url, accessToken string) (ui UserInfo, err
 		err = err2
 		return
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		err = rerror.NewE(i18n.T("could not get user info"))

--- a/account/accountusecase/accountinteractor/user_signup.go
+++ b/account/accountusecase/accountinteractor/user_signup.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"strings"
 	textTmpl "text/template"
+	"time"
 
 	"github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
@@ -53,6 +54,8 @@ var (
 
 	authTextTMPL *textTmpl.Template
 	authHTMLTMPL *htmlTmpl.Template
+
+	httpClient = &http.Client{Timeout: 30 * time.Second}
 )
 
 func init() {
@@ -289,11 +292,12 @@ func getOpenIDConfiguration(ctx context.Context, iss string) (c OpenIDConfigurat
 		return
 	}
 
-	res, err2 := http.DefaultClient.Do(req)
+	res, err2 := httpClient.Do(req)
 	if err2 != nil {
 		err = err2
 		return
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		err = rerror.NewE(i18n.T("could not get user info"))
@@ -320,11 +324,12 @@ func getUserInfo(ctx context.Context, url, accessToken string) (ui UserInfo, err
 	}
 
 	req.Header.Set("Authorization", "Bearer "+accessToken)
-	res, err2 := http.DefaultClient.Do(req)
+	res, err2 := httpClient.Do(req)
 	if err2 != nil {
 		err = err2
 		return
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		err = rerror.NewE(i18n.T("could not get user info"))

--- a/appx/server_test.go
+++ b/appx/server_test.go
@@ -60,7 +60,7 @@ func TestStartServer_ServesAndShutsDown(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status %d", resp.StatusCode)
 		}
@@ -115,7 +115,7 @@ func TestStartServer_H2C(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(resp.Body)
 		if string(body) != "HTTP/2.0" {
 			return fmt.Errorf("proto=%q, want HTTP/2.0", body)


### PR DESCRIPTION
## Finding addressed

- **[REL-01] [CRITICAL] No timeout + leaked response body on OIDC signup** — `http.DefaultClient.Do(req)` was used during signup with no per-request timeout (DefaultClient has infinite timeout), and `res.Body` was never closed in `getOpenIDConfiguration` (~292-306) or `getUserInfo` (~323-336). A slow/unresponsive OIDC issuer blocked signup goroutines indefinitely, and every call leaked a response body (FD + idle connection), so repeated signups could exhaust the FD limit / connection pool and 5xx all traffic sharing the process.

## Changes

- Added a package-level `httpClient = &http.Client{Timeout: 30 * time.Second}` and used it at both call sites instead of `http.DefaultClient`.
- Added `defer res.Body.Close()` after the `err != nil` guard at both call sites, so the body is always closed on success/error paths and a nil body is never closed.

Existing parsing, status-code checks, and error wrapping are unchanged.

## Verification

- `go build ./account/...` ✓
- `go vet ./account/...` ✓
- `go test ./account/accountusecase/...` ✓ (136 passed)