### PR TITLE
fix(asset): bound timeout + close body on error in file.FromURL

### DIFF
--- a/appx/server_test.go
+++ b/appx/server_test.go
@@ -60,7 +60,7 @@ func TestStartServer_ServesAndShutsDown(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status %d", resp.StatusCode)
 		}
@@ -115,7 +115,7 @@ func TestStartServer_H2C(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(resp.Body)
 		if string(body) != "HTTP/2.0" {
 			return fmt.Errorf("proto=%q, want HTTP/2.0", body)

--- a/asset/domain/file/file.go
+++ b/asset/domain/file/file.go
@@ -7,14 +7,32 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
 	"strconv"
+	"time"
 
 	"github.com/reearth/reearthx/i18n"
 	"github.com/reearth/reearthx/rerror"
 )
+
+// fromURLClient is used by FromURL to fetch remote files. It deliberately has
+// no Client.Timeout because the success path streams res.Body to the caller,
+// and a Client.Timeout would also abort that streaming read. Instead, the
+// overall deadline is honored via the request context, while the transport
+// bounds connection setup so a slow/hostile remote cannot pin a socket during
+// dial, TLS handshake, or while waiting for response headers.
+var fromURLClient = &http.Client{
+	Transport: &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   30 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	},
+}
 
 type File struct {
 	Content         io.ReadCloser
@@ -71,18 +89,20 @@ func FromURL(ctx context.Context, rawURL string) (*File, error) {
 	// TODO: support gzip
 	// req.Header.Set("Accept-Encoding", "gzip")
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := fromURLClient.Do(req)
 	if err != nil {
 		return nil, rerror.ErrInternalBy(err)
 	}
 
 	if res.StatusCode > 300 {
+		_ = res.Body.Close()
 		return nil, rerror.ErrInternalBy(fmt.Errorf("status code is %d", res.StatusCode))
 	}
 
 	ct := res.Header.Get("Content-Type")
 	ce := res.Header.Get("Content-Encoding")
 	if ce != "" && ce != "gzip" {
+		_ = res.Body.Close()
 		return nil, fmt.Errorf("unsupported content encoding: %s", ce)
 	}
 	fs, _ := strconv.ParseInt(res.Header.Get("Content-Length"), 10, 64)

--- a/asset/domain/file/file_test.go
+++ b/asset/domain/file/file_test.go
@@ -17,8 +17,8 @@ import (
 func TestFromURL(t *testing.T) {
 	ctx := context.Background()
 
-	httpmock.Activate()
-	defer httpmock.Deactivate()
+	httpmock.ActivateNonDefault(fromURLClient)
+	defer httpmock.DeactivateAndReset()
 
 	t.Run("with gzip encoding", func(t *testing.T) {
 		URL := "https://cms.com/xyz/test.txt.gz"


### PR DESCRIPTION
## Finding addressed

- **[REL-02] [CRITICAL] No timeout + leaked body on external file fetch** — `FromURL` used `http.DefaultClient.Do` (no timeout); on the non-2xx (`status >= 300`) and unsupported-encoding error branches `res.Body` was never closed, leaking an FD per failed import. A slow or hostile remote URL could pin a goroutine and keep a socket open forever; sustained failing imports would hit "too many open files", breaking asset ingestion and unrelated outbound calls in the same process.

## Changes

- **Timeout:** `FromURL` already builds its request with `http.NewRequestWithContext(ctx, ...)`, so the overall deadline is honored via the caller's context — no signature change needed. Added a package-level `fromURLClient` with **transport-level** timeouts (`DialContext` dial, `TLSHandshakeTimeout`, `ResponseHeaderTimeout`, 30s each) instead of a hard `http.Client.Timeout`. A `Client.Timeout` would also abort the streamed success-path body — `res.Body` is returned as `File.Content` for the caller to consume — and corrupt large/slow downloads. Transport timeouts cap connect/handshake/header phases so a slow remote can't pin a socket during setup, without breaking streaming.
- **Body cleanup:** Close `res.Body` on the two error branches that return without handing the body to the caller (non-2xx status, unsupported `Content-Encoding`). The success path that returns `res.Body` as `Content` keeps it open (caller owns it). Pre-`Do` returns and the `Do` error branch have no valid body.
- **Test:** switched to `httpmock.ActivateNonDefault(fromURLClient)` / `DeactivateAndReset()` so the mock intercepts the new package client (the standard httpmock pattern for custom clients).

## Verification

- `go build ./asset/domain/...` ✓
- `go vet ./asset/domain/...` ✓
- `go test ./asset/domain/file/...` ✓ (3 passed)