### PR TITLE
perf(asset): bound memory + batch queries in mongo asset layer

### DIFF
--- a/appx/server_test.go
+++ b/appx/server_test.go
@@ -60,7 +60,7 @@ func TestStartServer_ServesAndShutsDown(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("status %d", resp.StatusCode)
 		}
@@ -115,7 +115,7 @@ func TestStartServer_H2C(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(resp.Body)
 		if string(body) != "HTTP/2.0" {
 			return fmt.Errorf("proto=%q, want HTTP/2.0", body)

--- a/asset/infrastructure/mongo/asset.go
+++ b/asset/infrastructure/mongo/asset.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -317,40 +318,71 @@ func (r *Asset) TotalSizeByWorkspace(
 	return res.Size, nil
 }
 
+// removeByProjectBatchSize bounds how many asset docs are loaded into memory at
+// once while removing a whole project's assets, so memory stays constant even
+// for projects with hundreds of thousands of assets.
+const removeByProjectBatchSize = 1000
+
 func (r *Asset) RemoveByProjectWithFile(
 	ctx context.Context,
 	pid id.ProjectID,
 	f gateway.File,
 ) error {
-	projectAssets, err := r.find(ctx, bson.M{
-		"coresupport": true,
-		"project":     pid.String(),
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, a := range projectAssets {
-
-		if !r.workspaceFilter.CanWrite(a.Workspace()) {
-			return repo.ErrOperationDenied
+	// Keyset pagination over the asset id: each page fetches the next batch with
+	// id greater than the last one seen, ordered ascending. Because every
+	// processed asset is deleted (and all deleted ids are <= lastID), they never
+	// reappear in a later page, so the cursor stays correct even as rows are
+	// removed. Memory stays bounded to one batch regardless of project size.
+	lastID := ""
+	for {
+		filter := bson.M{
+			"coresupport": true,
+			"project":     pid.String(),
+		}
+		if lastID != "" {
+			filter["id"] = bson.M{"$gt": lastID}
 		}
 
-		aPath, err := url.Parse(a.URL())
-		if err != nil {
-			continue
+		c := mongodoc.NewAssetConsumer()
+		err := r.client.Find(ctx, r.readFilter(filter), c,
+			options.Find().
+				SetProjection(bson.M{"file": 0}).
+				SetSort(bson.D{{Key: "id", Value: 1}}).
+				SetLimit(removeByProjectBatchSize),
+		)
+		if err != nil && !errors.Is(err, rerror.ErrNotFound) {
+			return rerror.ErrInternalBy(err)
 		}
 
-		err = f.RemoveAsset(ctx, aPath)
-		if err != nil {
-			log.Print(err.Error())
+		batch := c.Result
+		if len(batch) == 0 {
+			break
 		}
 
-		err = r.Delete(ctx, a.ID())
-		if err != nil {
-			log.Print(err.Error())
+		for _, a := range batch {
+			if !r.workspaceFilter.CanWrite(a.Workspace()) {
+				return repo.ErrOperationDenied
+			}
+
+			aPath, err := url.Parse(a.URL())
+			if err != nil {
+				continue
+			}
+
+			if err := f.RemoveAsset(ctx, aPath); err != nil {
+				log.Print(err.Error())
+			}
+
+			if err := r.Delete(ctx, a.ID()); err != nil {
+				log.Print(err.Error())
+			}
 		}
 
+		lastID = batch[len(batch)-1].ID().String()
+
+		if len(batch) < removeByProjectBatchSize {
+			break
+		}
 	}
 
 	return nil

--- a/asset/infrastructure/mongo/asset_file.go
+++ b/asset/infrastructure/mongo/asset_file.go
@@ -91,6 +91,39 @@ func (r *AssetFile) FindByIDs(
 		return nil, err
 	}
 
+	// Collect every asset id whose files live in the asset_files collection so we
+	// can fetch them all in a single batched $in query instead of one query per
+	// flat-file asset.
+	flatIDs := make([]string, 0, len(c.Result))
+	for _, result := range c.Result {
+		if result.FlatFiles {
+			flatIDs = append(flatIDs, result.ID)
+		}
+	}
+
+	// flatFilesByAsset maps an asset id to its files, grouped from the single
+	// batched query below. Sorting by (assetid, page) preserves the same
+	// per-asset page ordering the previous per-asset query guaranteed.
+	flatFilesByAsset := make(map[string][]*asset.File, len(flatIDs))
+	if len(flatIDs) > 0 {
+		var afc mongodoc.AssetFilesConsumer
+		if err := r.assetFilesClient.Find(ctx, bson.M{
+			"assetid": bson.M{"$in": flatIDs},
+		}, &afc, options.Find().SetSort(bson.D{
+			{Key: "assetid", Value: 1},
+			{Key: "page", Value: 1},
+		})); err != nil {
+			return nil, err
+		}
+		grouped := make(map[string]mongodoc.AssetFilesDocument, len(flatIDs))
+		for _, page := range afc.Result() {
+			grouped[page.AssetID] = append(grouped[page.AssetID], page)
+		}
+		for assetID, pages := range grouped {
+			flatFilesByAsset[assetID] = pages.Model()
+		}
+	}
+
 	for _, result := range c.Result {
 		assetID := result.ID
 		f := result.File.Model()
@@ -99,16 +132,7 @@ func (r *AssetFile) FindByIDs(
 		}
 
 		if result.FlatFiles {
-			var afc mongodoc.AssetFilesConsumer
-			if err := r.assetFilesClient.Find(ctx, bson.M{
-				"assetid": assetID,
-			}, &afc, options.Find().SetSort(bson.D{
-				{Key: "page", Value: 1},
-			})); err != nil {
-				return nil, err
-			}
-			files := afc.Result().Model()
-			f.SetFiles(files)
+			f.SetFiles(flatFilesByAsset[assetID])
 		} else if len(f.Children()) > 0 {
 			f.SetFiles(f.FlattenChildren())
 		}


### PR DESCRIPTION
## Findings addressed

- **[SCA-02] [CRITICAL] RemoveByProjectWithFile loads entire project's assets into memory unpaginated** — `r.find(ctx, {coresupport:true, project:pid})` had no `$limit`/pagination; all matching asset docs loaded into one slice, then each file + row was deleted serially. Projects with hundreds of thousands of assets caused OOM and multi-minute latency; a single project-delete could take down the process.
- **[SCA-04] [HIGH] AssetFile.FindByIDs does a separate DB query per flat-file asset** — the initial query was batched via `$in`, but the per-result loop called `Find({assetid: assetID})` once per asset with `FlatFiles=true`, i.e. O(N) extra round-trips per request.

## Changes

**SCA-02 — `RemoveByProjectWithFile` (asset.go):** Keyset pagination over the asset `id` field in bounded batches (`removeByProjectBatchSize = 1000`). Each iteration fetches `{coresupport, project, id > lastID}` sorted by `id` asc with a limit, processes the batch (remove file + delete row), then advances `lastID`. Loop ends on a short/empty page.
- Keyset (not skip/offset) is robust against concurrent row deletion: every deleted id is `<= lastID`, so it can't reappear on a later page — no rows skipped or double-processed.
- Same filter (incl. the existing read-ACL wrapping), same set of assets/files removed, same error semantics (per-asset errors logged and non-fatal; `ErrOperationDenied` on write-deny). Empty page (`rerror.ErrNotFound`) is treated as normal end-of-data. Memory bounded to one batch.

**SCA-04 — `AssetFile.FindByIDs` (asset_file.go):** Collect all flat-file asset ids, issue a single `Find({assetid: {$in: flatIDs}})` sorted by `(assetid, page)`, group page docs by `assetid` into a map, and attach from the map in the result loop.
- Per-asset page order preserved (sorted by `page` within each `assetid`); outer iteration order unchanged; empty-files and not-found semantics unchanged.

No exported signatures changed.

## Verification

- `go build ./asset/...` ✓
- `go vet ./asset/infrastructure/mongo/...` ✓
- `go test ./asset/infrastructure/mongo/...` ✓ (390 passed against live mongo, 0 failures/skips)