### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,21 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearthx
+  namespace: reearth
+  description: Common Go library used by every Re:Earth Go service (auth, GraphQL,
+    MongoDB, tracing)
+  annotations:
+    github.com/project-slug: reearth/reearthx
+  links:
+  - url: https://github.com/reearth/reearthx
+    title: GitHub
+    icon: github
+  tags:
+  - go
+  - library
+  - shared
+spec:
+  type: library
+  lifecycle: production
+  owner: reearth/cto-office


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearthx` (namespace `reearth`)
- **Owner:** `reearth/cto-office`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.