### PR TITLE
feat(usecasex,pgxx): reusable Transactor (WithinTransaction) + pgx Postgres support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,18 @@ jobs:
         image: mongo:5-focal
         ports:
           - 27017:27017
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: reearth
+          POSTGRES_PASSWORD: reearth
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U reearth"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: set up
         uses: actions/setup-go@v3
@@ -38,6 +50,7 @@ jobs:
         run: go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic -timeout 10m
         env:
           REEARTH_DB: mongodb://localhost
+          REEARTH_DB_PG: postgres://reearth:reearth@localhost:5432/postgres?sslmode=disable
       - name: Send coverage report
         uses: codecov/codecov-action@v2
         with:

--- a/authserver/postgres.go
+++ b/authserver/postgres.go
@@ -1,0 +1,228 @@
+package authserver
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/zitadel/oidc/pkg/oidc"
+)
+
+// Postgres is a RequestRepo backed by Postgres via pgxx. It mirrors Mongo: a
+// single auth_requests table holds the OAuth2 authorization-request state, with
+// the variable-length scopes/audiences/code_challenge persisted as jsonb.
+type Postgres struct {
+	client *pgxx.Client
+}
+
+var _ RequestRepo = (*Postgres)(nil)
+
+func NewPostgres(client *pgxx.Client) *Postgres {
+	return &Postgres{client: client}
+}
+
+// Init creates the auth_requests table and its lookup indexes if they do not
+// exist. Like Mongo.Init (which ensures indexes), it lets the repo manage its
+// own storage so a consumer need not wire the schema separately. Consumers that
+// own their schema declaratively (e.g. via Atlas) may instead fold the
+// equivalent DDL into their schema and skip this call.
+func (r *Postgres) Init(ctx context.Context) error {
+	db := r.client.DB(ctx)
+	for _, stmt := range []string{
+		`CREATE TABLE IF NOT EXISTS auth_requests (
+			id             text PRIMARY KEY,
+			client_id      text NOT NULL DEFAULT '',
+			subject        text NOT NULL DEFAULT '',
+			code           text NOT NULL DEFAULT '',
+			state          text NOT NULL DEFAULT '',
+			response_type  text NOT NULL DEFAULT '',
+			scopes         jsonb,
+			audiences      jsonb,
+			redirect_uri   text NOT NULL DEFAULT '',
+			nonce          text NOT NULL DEFAULT '',
+			code_challenge jsonb,
+			authorized_at  timestamptz
+		)`,
+		`CREATE INDEX IF NOT EXISTS auth_requests_code_idx ON auth_requests (code)`,
+		`CREATE INDEX IF NOT EXISTS auth_requests_subject_idx ON auth_requests (subject)`,
+	} {
+		if _, err := db.Exec(ctx, stmt); err != nil {
+			return rerror.ErrInternalByWithContext(ctx, pgxx.WrapError(err))
+		}
+	}
+	return nil
+}
+
+func (r *Postgres) FindByID(ctx context.Context, id RequestID) (*Request, error) {
+	return r.findOne(ctx, "id = $1", id.String())
+}
+
+func (r *Postgres) FindByCode(ctx context.Context, s string) (*Request, error) {
+	return r.findOne(ctx, "code = $1", s)
+}
+
+func (r *Postgres) FindBySubject(ctx context.Context, s string) (*Request, error) {
+	return r.findOne(ctx, "subject = $1", s)
+}
+
+func (r *Postgres) Save(ctx context.Context, request *Request) error {
+	d, err := newPostgresDocument(request)
+	if err != nil {
+		return rerror.ErrInternalByWithContext(ctx, err)
+	}
+	const q = `INSERT INTO auth_requests (
+		id, client_id, subject, code, state, response_type,
+		scopes, audiences, redirect_uri, nonce, code_challenge, authorized_at
+	) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+	ON CONFLICT (id) DO UPDATE SET
+		client_id      = EXCLUDED.client_id,
+		subject        = EXCLUDED.subject,
+		code           = EXCLUDED.code,
+		state          = EXCLUDED.state,
+		response_type  = EXCLUDED.response_type,
+		scopes         = EXCLUDED.scopes,
+		audiences      = EXCLUDED.audiences,
+		redirect_uri   = EXCLUDED.redirect_uri,
+		nonce          = EXCLUDED.nonce,
+		code_challenge = EXCLUDED.code_challenge,
+		authorized_at  = EXCLUDED.authorized_at`
+	if _, err := r.client.DB(ctx).Exec(ctx, q,
+		d.ID, d.ClientID, d.Subject, d.Code, d.State, d.ResponseType,
+		d.Scopes, d.Audiences, d.RedirectURI, d.Nonce, d.CodeChallenge, d.AuthorizedAt,
+	); err != nil {
+		return rerror.ErrInternalByWithContext(ctx, pgxx.WrapError(err))
+	}
+	return nil
+}
+
+// Remove deletes the request, returning rerror.ErrNotFound when no row matched —
+// mirroring Mongo.RemoveOne so the two backends behave identically.
+func (r *Postgres) Remove(ctx context.Context, id RequestID) error {
+	tag, err := r.client.DB(ctx).Exec(ctx, `DELETE FROM auth_requests WHERE id = $1`, id.String())
+	if err != nil {
+		return rerror.ErrInternalByWithContext(ctx, pgxx.WrapError(err))
+	}
+	if tag.RowsAffected() == 0 {
+		return rerror.ErrNotFound
+	}
+	return nil
+}
+
+func (r *Postgres) findOne(ctx context.Context, where string, arg any) (*Request, error) {
+	const cols = `id, client_id, subject, code, state, response_type,
+		scopes, audiences, redirect_uri, nonce, code_challenge, authorized_at`
+	row := r.client.DB(ctx).QueryRow(ctx, `SELECT `+cols+` FROM auth_requests WHERE `+where, arg)
+
+	var d postgresDocument
+	if err := row.Scan(
+		&d.ID, &d.ClientID, &d.Subject, &d.Code, &d.State, &d.ResponseType,
+		&d.Scopes, &d.Audiences, &d.RedirectURI, &d.Nonce, &d.CodeChallenge, &d.AuthorizedAt,
+	); err != nil {
+		return nil, pgxx.MapError(err)
+	}
+	return d.Model()
+}
+
+// postgresDocument is the row shape. scopes/audiences/code_challenge are jsonb,
+// scanned as raw bytes and decoded in Model() to keep the SQL types simple.
+type postgresDocument struct {
+	ID            string
+	ClientID      string
+	Subject       string
+	Code          string
+	State         string
+	ResponseType  string
+	Scopes        []byte
+	Audiences     []byte
+	RedirectURI   string
+	Nonce         string
+	CodeChallenge []byte
+	AuthorizedAt  *time.Time
+}
+
+type postgresCodeChallenge struct {
+	Challenge string `json:"challenge"`
+	Method    string `json:"method"`
+}
+
+func newPostgresDocument(req *Request) (*postgresDocument, error) {
+	if req == nil {
+		return nil, nil
+	}
+	scopes, err := pgxx.MarshalJSONBSlice(req.GetScopes())
+	if err != nil {
+		return nil, err
+	}
+	audiences, err := pgxx.MarshalJSONBSlice(req.GetAudience())
+	if err != nil {
+		return nil, err
+	}
+	var cc []byte
+	if c := req.GetCodeChallenge(); c != nil {
+		if cc, err = json.Marshal(postgresCodeChallenge{
+			Challenge: c.Challenge,
+			Method:    string(c.Method),
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return &postgresDocument{
+		ID:            req.GetID(),
+		ClientID:      req.GetClientID(),
+		Subject:       req.GetSubject(),
+		Code:          req.GetCode(),
+		State:         req.GetState(),
+		ResponseType:  string(req.GetResponseType()),
+		Scopes:        scopes,
+		Audiences:     audiences,
+		RedirectURI:   req.GetRedirectURI(),
+		Nonce:         req.GetNonce(),
+		CodeChallenge: cc,
+		AuthorizedAt:  req.AuthorizedAt(),
+	}, nil
+}
+
+func (d *postgresDocument) Model() (*Request, error) {
+	if d == nil {
+		return nil, nil
+	}
+	id, err := RequestIDFrom(d.ID)
+	if err != nil {
+		return nil, err
+	}
+	scopes, err := pgxx.UnmarshalJSONBSlice[string](d.Scopes)
+	if err != nil {
+		return nil, err
+	}
+	audiences, err := pgxx.UnmarshalJSONBSlice[string](d.Audiences)
+	if err != nil {
+		return nil, err
+	}
+	var cc *oidc.CodeChallenge
+	if len(d.CodeChallenge) > 0 {
+		var pc postgresCodeChallenge
+		if err := json.Unmarshal(d.CodeChallenge, &pc); err != nil {
+			return nil, err
+		}
+		cc = &oidc.CodeChallenge{
+			Challenge: pc.Challenge,
+			Method:    oidc.CodeChallengeMethod(pc.Method),
+		}
+	}
+	return NewRequest().
+		ID(id).
+		ClientID(d.ClientID).
+		Subject(d.Subject).
+		Code(d.Code).
+		State(d.State).
+		ResponseType(oidc.ResponseType(d.ResponseType)).
+		Scopes(scopes).
+		Audiences(audiences).
+		RedirectURI(d.RedirectURI).
+		Nonce(d.Nonce).
+		CodeChallenge(cc).
+		AuthorizedAt(d.AuthorizedAt).
+		Build()
+}

--- a/authserver/postgres_test.go
+++ b/authserver/postgres_test.go
@@ -1,0 +1,184 @@
+package authserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/pgxx/pgxtest"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zitadel/oidc/pkg/oidc"
+)
+
+func newPostgresRepo(t *testing.T) *Postgres {
+	t.Helper()
+	pool := pgxtest.Connect(t)(t)
+	r := NewPostgres(pgxx.NewClient(pool))
+	require.NoError(t, r.Init(context.Background()))
+	return r
+}
+
+func TestNewPostgres(t *testing.T) {
+	c := pgxx.NewClient(nil)
+	assert.Equal(t, &Postgres{client: c}, NewPostgres(c))
+}
+
+func TestPostgres_FindByID(t *testing.T) {
+	r := newPostgresRepo(t)
+	ctx := context.Background()
+	id := NewRequestID()
+	want := NewRequest().ID(id).MustBuild()
+
+	got, err := r.FindByID(ctx, id)
+	assert.Nil(t, got)
+	assert.Same(t, rerror.ErrNotFound, err)
+
+	_, err = r.client.DB(ctx).Exec(ctx, `INSERT INTO auth_requests (id) VALUES ($1)`, id.String())
+	require.NoError(t, err)
+
+	got, err = r.FindByID(ctx, id)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestPostgres_FindByCode(t *testing.T) {
+	r := newPostgresRepo(t)
+	ctx := context.Background()
+	want := NewRequest().NewID().Code("aaa").MustBuild()
+
+	got, err := r.FindByCode(ctx, "aaa")
+	assert.Nil(t, got)
+	assert.Same(t, rerror.ErrNotFound, err)
+
+	_, err = r.client.DB(ctx).Exec(ctx, `INSERT INTO auth_requests (id, code) VALUES ($1, $2)`, want.GetID(), "aaa")
+	require.NoError(t, err)
+
+	got, err = r.FindByCode(ctx, "aaa")
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestPostgres_FindBySubject(t *testing.T) {
+	r := newPostgresRepo(t)
+	ctx := context.Background()
+	want := NewRequest().NewID().Subject("sss").MustBuild()
+
+	got, err := r.FindBySubject(ctx, "sss")
+	assert.Nil(t, got)
+	assert.Same(t, rerror.ErrNotFound, err)
+
+	_, err = r.client.DB(ctx).Exec(ctx, `INSERT INTO auth_requests (id, subject) VALUES ($1, $2)`, want.GetID(), "sss")
+	require.NoError(t, err)
+
+	got, err = r.FindBySubject(ctx, "sss")
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestPostgres_Save(t *testing.T) {
+	r := newPostgresRepo(t)
+	ctx := context.Background()
+	aa := time.Now()
+	req := NewRequest().NewID().
+		ClientID("client").
+		Subject("sub").
+		Code("code").
+		State("state").
+		ResponseType("rt").
+		Scopes([]string{"a", "openid"}).
+		Audiences([]string{"aud"}).
+		RedirectURI("ru").
+		Nonce("nonce").
+		CodeChallenge(&oidc.CodeChallenge{
+			Challenge: "xxx",
+			Method:    oidc.CodeChallengeMethodPlain,
+		}).
+		AuthorizedAt(&aa).
+		MustBuild()
+
+	require.NoError(t, r.Save(ctx, req))
+
+	// Inspect the persisted row directly (mirrors the Mongo test's bson check).
+	var (
+		clientID, subject, code, state, responseType, redirectURI, nonce string
+		scopesB, audiencesB, ccB                                         []byte
+		authorizedAt                                                     *time.Time
+	)
+	err := r.client.DB(ctx).QueryRow(ctx,
+		`SELECT client_id, subject, code, state, response_type, scopes, audiences, redirect_uri, nonce, code_challenge, authorized_at
+		 FROM auth_requests WHERE id = $1`, req.GetID()).
+		Scan(&clientID, &subject, &code, &state, &responseType, &scopesB, &audiencesB, &redirectURI, &nonce, &ccB, &authorizedAt)
+	require.NoError(t, err)
+
+	assert.Equal(t, "client", clientID)
+	assert.Equal(t, "sub", subject)
+	assert.Equal(t, "code", code)
+	assert.Equal(t, "state", state)
+	assert.Equal(t, "rt", responseType)
+	assert.Equal(t, "ru", redirectURI)
+	assert.Equal(t, "nonce", nonce)
+	scopes, err := pgxx.UnmarshalJSONBSlice[string](scopesB)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "openid", "profile", "email"}, scopes) // essential scopes appended
+	audiences, err := pgxx.UnmarshalJSONBSlice[string](audiencesB)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"aud"}, audiences)
+	assert.JSONEq(t, `{"challenge":"xxx","method":"plain"}`, string(ccB))
+	require.NotNil(t, authorizedAt)
+	assert.WithinDuration(t, aa, *authorizedAt, time.Millisecond)
+
+	// Read path round-trips every field (compared via accessors so scope
+	// augmentation matches on both sides).
+	got, err := r.FindByID(ctx, req.ID())
+	require.NoError(t, err)
+	assert.Equal(t, req.GetClientID(), got.GetClientID())
+	assert.Equal(t, req.GetSubject(), got.GetSubject())
+	assert.Equal(t, req.GetCode(), got.GetCode())
+	assert.Equal(t, req.GetState(), got.GetState())
+	assert.Equal(t, req.GetResponseType(), got.GetResponseType())
+	assert.Equal(t, req.GetScopes(), got.GetScopes())
+	assert.Equal(t, req.GetAudience(), got.GetAudience())
+	assert.Equal(t, req.GetRedirectURI(), got.GetRedirectURI())
+	assert.Equal(t, req.GetNonce(), got.GetNonce())
+	assert.Equal(t, req.GetCodeChallenge(), got.GetCodeChallenge())
+	require.NotNil(t, got.AuthorizedAt())
+	assert.WithinDuration(t, *req.AuthorizedAt(), *got.AuthorizedAt(), time.Millisecond)
+}
+
+func TestPostgres_Save_Upsert(t *testing.T) {
+	r := newPostgresRepo(t)
+	ctx := context.Background()
+	id := NewRequestID()
+
+	require.NoError(t, r.Save(ctx, NewRequest().ID(id).Code("first").MustBuild()))
+	require.NoError(t, r.Save(ctx, NewRequest().ID(id).Code("second").MustBuild()))
+
+	got, err := r.FindByID(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, "second", got.GetCode())
+
+	// FindByCode reflects the updated value, and the stale code is gone.
+	_, err = r.FindByCode(ctx, "first")
+	assert.Same(t, rerror.ErrNotFound, err)
+	got, err = r.FindByCode(ctx, "second")
+	require.NoError(t, err)
+	assert.Equal(t, id, got.ID())
+}
+
+func TestPostgres_Remove(t *testing.T) {
+	r := newPostgresRepo(t)
+	ctx := context.Background()
+	id := NewRequestID()
+
+	// Removing a missing row reports not-found, mirroring Mongo.
+	assert.Same(t, rerror.ErrNotFound, r.Remove(ctx, id))
+
+	require.NoError(t, r.Save(ctx, NewRequest().ID(id).MustBuild()))
+	require.NoError(t, r.Remove(ctx, id))
+
+	_, err := r.FindByID(ctx, id)
+	assert.Same(t, rerror.ErrNotFound, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/iancoleman/orderedmap v0.3.0
 	github.com/iancoleman/strcase v0.3.0
+	github.com/jackc/pgx/v5 v5.7.2
 	github.com/jarcoal/httpmock v1.4.0
 	github.com/jpillora/opts v1.2.3
 	github.com/kennygrant/sanitize v1.2.4
@@ -102,6 +103,9 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,14 @@ github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJ
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/inconshreveable/log15 v0.0.0-20170622235902-74a0988b5f80/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.7.2 h1:mLoDLV6sonKlvjIEsV56SkWNCnuNv531l94GaIzO+XI=
+github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jarcoal/httpmock v1.4.0 h1:BvhqnH0JAYbNudL2GMJKgOHe2CtKlzJ/5rWKyp+hc2k=
 github.com/jarcoal/httpmock v1.4.0/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/jpillora/opts v1.2.3 h1:Q0YuOM7y0BlunHJ7laR1TUxkUA7xW8A2rciuZ70xs8g=

--- a/pgxx/client.go
+++ b/pgxx/client.go
@@ -1,0 +1,84 @@
+package pgxx
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearthx/usecasex"
+)
+
+// Client is a pgx-backed database handle — the Postgres analogue of mongox.Client.
+// It resolves the executor for the current context and runs functions within a
+// transaction. It implements usecasex.Transactor, so it can back
+// repo.Container.Transaction directly.
+type Client struct {
+	pool    *pgxpool.Pool
+	retries int
+}
+
+var _ usecasex.Transactor = (*Client)(nil)
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithTxRetry makes WithinTransaction retry up to n additional times when the
+// callback returns an error matching usecasex.ErrTransaction (e.g. a Postgres
+// serialization failure mapped via WrapError/MapError). Each retry re-begins a
+// fresh transaction. Default is 0 (single attempt). Nested calls (an ambient tx
+// already in ctx) never retry — only the outermost call owns the transaction.
+func WithTxRetry(n int) Option {
+	return func(c *Client) { c.retries = n }
+}
+
+func NewClient(pool *pgxpool.Pool, opts ...Option) *Client {
+	c := &Client{pool: pool}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// Pool returns the underlying connection pool.
+func (c *Client) Pool() *pgxpool.Pool { return c.pool }
+
+// DB returns the executor for ctx: the ambient transaction if one is active
+// (see WithinTransaction), otherwise the pool. Repositories build their sqlc
+// queries with gen.New(client.DB(ctx)) so they transparently join a transaction.
+func (c *Client) DB(ctx context.Context) DBTX {
+	return Executor(ctx, c.pool)
+}
+
+// WithinTransaction runs fn inside a transaction, committing on a nil return and
+// rolling back on error. If a transaction is already active in ctx, fn runs on
+// that transaction — nested calls compose, with no nested BEGIN (and no retry).
+// When configured with WithTxRetry, the outermost call retries on
+// usecasex.ErrTransaction with a fresh transaction.
+func (c *Client) WithinTransaction(ctx context.Context, fn func(ctx context.Context) error) error {
+	if _, ok := txFromContext(ctx); ok {
+		return fn(ctx)
+	}
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = c.runOnce(ctx, fn)
+		if err == nil || !errors.Is(err, usecasex.ErrTransaction) || attempt >= c.retries {
+			return err
+		}
+	}
+}
+
+func (c *Client) runOnce(ctx context.Context, fn func(ctx context.Context) error) error {
+	tx, err := c.pool.Begin(ctx)
+	if err != nil {
+		return rerror.ErrInternalByWithContext(ctx, err)
+	}
+	if err := fn(ContextWithTx(ctx, tx)); err != nil {
+		_ = tx.Rollback(ctx)
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return rerror.ErrInternalByWithContext(ctx, err)
+	}
+	return nil
+}

--- a/pgxx/client_test.go
+++ b/pgxx/client_test.go
@@ -1,0 +1,69 @@
+package pgxx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/pgxx/pgxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupItems(t *testing.T) (context.Context, *pgxx.Client, func(context.Context) int, func(context.Context, string) error) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `CREATE TABLE items (id text PRIMARY KEY)`)
+	require.NoError(t, err)
+	c := pgxx.NewClient(pool)
+	count := func(ctx context.Context) int {
+		var n int
+		require.NoError(t, c.DB(ctx).QueryRow(ctx, `SELECT count(*) FROM items`).Scan(&n))
+		return n
+	}
+	insert := func(ctx context.Context, id string) error {
+		_, err := c.DB(ctx).Exec(ctx, `INSERT INTO items (id) VALUES ($1)`, id)
+		return err
+	}
+	return ctx, c, count, insert
+}
+
+func TestClient_WithinTransaction_Commits(t *testing.T) {
+	ctx, c, count, insert := setupItems(t)
+	err := c.WithinTransaction(ctx, func(ctx context.Context) error { return insert(ctx, "a") })
+	require.NoError(t, err)
+	assert.Equal(t, 1, count(ctx))
+}
+
+func TestClient_WithinTransaction_RollsBackOnError(t *testing.T) {
+	ctx, c, count, insert := setupItems(t)
+	sentinel := assert.AnError
+	err := c.WithinTransaction(ctx, func(ctx context.Context) error {
+		if e := insert(ctx, "a"); e != nil {
+			return e
+		}
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 0, count(ctx))
+}
+
+// Nested WithinTransaction must reuse the ambient tx: a rollback at the outer
+// level discards the inner insert too (no independent nested BEGIN).
+func TestClient_WithinTransaction_NestedComposes(t *testing.T) {
+	ctx, c, count, insert := setupItems(t)
+	sentinel := assert.AnError
+	err := c.WithinTransaction(ctx, func(ctx context.Context) error {
+		if e := insert(ctx, "a"); e != nil {
+			return e
+		}
+		if e := c.WithinTransaction(ctx, func(ctx context.Context) error {
+			return insert(ctx, "b")
+		}); e != nil {
+			return e
+		}
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 0, count(ctx), "nested insert must roll back with the outer tx")
+}

--- a/pgxx/collect.go
+++ b/pgxx/collect.go
@@ -1,0 +1,20 @@
+package pgxx
+
+// OrderByIDs reorders items to match the order of ids, matching each item by
+// key(item). An id with no matching item gets the zero value of T (nil for
+// pointer types). This is the FindByIDs contract repositories share: fetch rows
+// with `WHERE id = ANY($1)` (arbitrary order), then restore the requested order
+// with nil placeholders for missing ids.
+//
+// Filter items (e.g. by workspace) before calling this; unmatched ids become nil.
+func OrderByIDs[K comparable, T any](ids []K, items []T, key func(T) K) []T {
+	byID := make(map[K]T, len(items))
+	for _, it := range items {
+		byID[key(it)] = it
+	}
+	out := make([]T, len(ids))
+	for i, id := range ids {
+		out[i] = byID[id] // zero value (nil) when absent
+	}
+	return out
+}

--- a/pgxx/collect_test.go
+++ b/pgxx/collect_test.go
@@ -1,0 +1,30 @@
+package pgxx_test
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderByIDs(t *testing.T) {
+	type item struct {
+		id   string
+		name string
+	}
+	items := []*item{{"b", "B"}, {"a", "A"}} // arbitrary fetch order
+	key := func(i *item) string { return i.id }
+
+	got := pgxx.OrderByIDs([]string{"a", "missing", "b"}, items, key)
+	assert.Len(t, got, 3)
+	assert.Equal(t, "A", got[0].name)
+	assert.Nil(t, got[1]) // missing id -> zero value (nil)
+	assert.Equal(t, "B", got[2].name)
+}
+
+func TestIsUniqueViolation(t *testing.T) {
+	assert.True(t, pgxx.IsUniqueViolation(&pgconn.PgError{Code: "23505"}))
+	assert.False(t, pgxx.IsUniqueViolation(&pgconn.PgError{Code: "40001"}))
+	assert.False(t, pgxx.IsUniqueViolation(nil))
+}

--- a/pgxx/coverage_test.go
+++ b/pgxx/coverage_test.go
@@ -1,0 +1,155 @@
+package pgxx_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/pgxx/pgxtest"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearthx/usecasex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- #1 retry contract ---
+
+func TestClient_WithinTransaction_RetriesOnErrTransaction(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	c := pgxx.NewClient(pool, pgxx.WithTxRetry(2))
+
+	calls := 0
+	err := c.WithinTransaction(ctx, func(ctx context.Context) error {
+		calls++
+		if calls == 1 {
+			return pgxx.WrapError(&pgconn.PgError{Code: "40001"}) // serialization -> retryable
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "fn should run twice: fail once (retryable) then succeed")
+}
+
+func TestClient_WithinTransaction_NoRetryByDefault(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	c := pgxx.NewClient(pool) // default: single attempt
+
+	calls := 0
+	err := c.WithinTransaction(ctx, func(ctx context.Context) error {
+		calls++
+		return pgxx.WrapError(&pgconn.PgError{Code: "40001"})
+	})
+	assert.ErrorIs(t, err, usecasex.ErrTransaction)
+	assert.Equal(t, 1, calls, "default client must not retry")
+}
+
+// --- #5 nested WithinTransaction commits via the single outer tx ---
+
+func TestClient_WithinTransaction_NestedCommits(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `CREATE TABLE nested_items (id text PRIMARY KEY)`)
+	require.NoError(t, err)
+	c := pgxx.NewClient(pool)
+	ins := func(ctx context.Context, id string) error {
+		_, e := c.DB(ctx).Exec(ctx, `INSERT INTO nested_items (id) VALUES ($1)`, id)
+		return e
+	}
+
+	require.NoError(t, c.WithinTransaction(ctx, func(ctx context.Context) error {
+		if e := ins(ctx, "a"); e != nil {
+			return e
+		}
+		return c.WithinTransaction(ctx, func(ctx context.Context) error { return ins(ctx, "b") })
+	}))
+
+	var n int
+	require.NoError(t, c.DB(ctx).QueryRow(ctx, `SELECT count(*) FROM nested_items`).Scan(&n))
+	assert.Equal(t, 2, n)
+}
+
+// --- #2 double-unlock safety ---
+
+func TestAdvisoryLock_UnlockIsIdempotent(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	unlock, err := pgxx.AdvisoryLock(ctx, pool, 777)
+	require.NoError(t, err)
+	require.NoError(t, unlock(ctx))
+	require.NotPanics(t, func() {
+		assert.NoError(t, unlock(ctx)) // second call: no-op, no panic
+	})
+}
+
+// --- #7 CountAndList placeholder math + caller-slice isolation ---
+
+type ciItem struct {
+	ID  string
+	Grp string
+}
+
+func TestCountAndList_ArgsIsolationAndPaging(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `CREATE TABLE ci_items (id text PRIMARY KEY, grp text)`)
+	require.NoError(t, err)
+	for _, id := range []string{"a", "b", "c"} {
+		_, e := pool.Exec(ctx, `INSERT INTO ci_items (id, grp) VALUES ($1, 'g')`, id)
+		require.NoError(t, e)
+	}
+	db := pgxx.NewClient(pool).DB(ctx)
+	args := []any{"g"}
+
+	rows, total, err := pgxx.CountAndList[ciItem](ctx, db,
+		`SELECT count(*) FROM ci_items WHERE grp = $1`,
+		`SELECT id, grp FROM ci_items WHERE grp = $1 ORDER BY id`,
+		args, 2, 1, pgx.RowToStructByPos[ciItem])
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	require.Len(t, rows, 2) // LIMIT 2 OFFSET 1 -> b, c
+	assert.Equal(t, "b", rows[0].ID)
+	assert.Equal(t, "c", rows[1].ID)
+	assert.Equal(t, []any{"g"}, args, "caller args slice must not be mutated")
+}
+
+// --- #8 OrderByIDs edges ---
+
+func TestOrderByIDs_Edges(t *testing.T) {
+	type item struct{ id, v string }
+	key := func(i *item) string { return i.id }
+	items := []*item{{"a", "A"}, {"a", "A2"}} // duplicate key: last wins
+
+	got := pgxx.OrderByIDs([]string{"a", "a", "x"}, items, key)
+	require.Len(t, got, 3)
+	assert.Equal(t, "A2", got[0].v)
+	assert.Equal(t, "A2", got[1].v) // duplicate id resolves to the same item
+	assert.Nil(t, got[2])           // missing id -> nil
+
+	assert.Empty(t, pgxx.OrderByIDs[string, *item](nil, nil, key))
+}
+
+// --- #11 JSONB null / malformed ---
+
+func TestJSONBSlice_NullAndMalformed(t *testing.T) {
+	out, err := pgxx.UnmarshalJSONBSlice[kv]([]byte("null"))
+	require.NoError(t, err)
+	assert.Nil(t, out) // JSON null decodes to a nil slice
+
+	_, err = pgxx.UnmarshalJSONBSlice[kv]([]byte("{not json"))
+	assert.Error(t, err)
+}
+
+// --- #12 MapError passes unique violations through ---
+
+func TestMapError_UniqueViolationPassesThrough(t *testing.T) {
+	uerr := &pgconn.PgError{Code: "23505"}
+	got := pgxx.MapError(uerr)
+	assert.False(t, errors.Is(got, rerror.ErrNotFound))
+	assert.False(t, errors.Is(got, usecasex.ErrTransaction))
+	assert.True(t, pgxx.IsUniqueViolation(got))
+}

--- a/pgxx/errors.go
+++ b/pgxx/errors.go
@@ -1,0 +1,64 @@
+package pgxx
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearthx/usecasex"
+)
+
+// IsSerializationError reports whether err is a Postgres serialization failure
+// (40001) or deadlock (40P01) — the cases worth retrying.
+func IsSerializationError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "40001" || pgErr.Code == "40P01"
+	}
+	return false
+}
+
+// IsUniqueViolation reports whether err is a Postgres unique_violation (23505).
+// Repositories use it to translate a duplicate-key error into a domain
+// "already exists" result.
+func IsUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// WrapError maps a Postgres serialization failure to usecasex.ErrTransaction.
+// Other errors (and nil) pass through unchanged.
+//
+// Call it in the REPOSITORY layer on errors returned from queries, because the
+// serialization failure surfaces on the failing statement. The wrap only causes
+// a retry when the Transactor is configured to retry — a pgxx.Client created
+// with WithTxRetry(n>0), or usecasex.NewTransactor(t, n>0). With a default
+// single-attempt Client the wrap affects error classification only, not retry.
+func WrapError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if IsSerializationError(err) {
+		return errors.Join(usecasex.ErrTransaction, err)
+	}
+	return err
+}
+
+// MapError translates common pgx errors into reearthx domain errors for repos:
+// no rows -> rerror.ErrNotFound, serialization failure -> usecasex.ErrTransaction
+// (retried only when the Transactor is configured to retry; see WrapError),
+// everything else passes through. nil -> nil.
+//
+// It is opt-in: call it only where a missing row should be a not-found error.
+// Finds that return (nil, nil) on no rows should test pgx.ErrNoRows themselves
+// and skip MapError for that case.
+func MapError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return rerror.ErrNotFound
+	}
+	return WrapError(err)
+}

--- a/pgxx/errors_test.go
+++ b/pgxx/errors_test.go
@@ -1,0 +1,30 @@
+package pgxx_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/usecasex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSerializationError(t *testing.T) {
+	assert.True(t, pgxx.IsSerializationError(&pgconn.PgError{Code: "40001"}))
+	assert.True(t, pgxx.IsSerializationError(&pgconn.PgError{Code: "40P01"}))
+	assert.False(t, pgxx.IsSerializationError(&pgconn.PgError{Code: "23505"}))
+	assert.False(t, pgxx.IsSerializationError(errors.New("nope")))
+	assert.False(t, pgxx.IsSerializationError(nil))
+}
+
+func TestWrapError_SerializationBecomesRetryable(t *testing.T) {
+	err := pgxx.WrapError(&pgconn.PgError{Code: "40001"})
+	assert.True(t, errors.Is(err, usecasex.ErrTransaction))
+}
+
+func TestWrapError_PassesThroughOthers(t *testing.T) {
+	orig := errors.New("boom")
+	assert.Equal(t, orig, pgxx.WrapError(orig))
+	assert.Nil(t, pgxx.WrapError(nil))
+}

--- a/pgxx/example_test.go
+++ b/pgxx/example_test.go
@@ -1,0 +1,35 @@
+package pgxx_test
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/reearth/reearthx/pgxx"
+)
+
+// Example shows the golden-path shape of a Postgres repository built on pgxx:
+// hold a *pgxx.Client, resolve the executor with DB(ctx) (which transparently
+// joins any ambient transaction), map errors with MapError, and wrap
+// multi-write operations in WithinTransaction so they commit/roll back together.
+func Example() {
+	var pool *pgxpool.Pool // obtained from pgxpool.New(ctx, dsn)
+
+	// Construct once at boot. WithTxRetry opts into serialization-failure retries.
+	client := pgxx.NewClient(pool, pgxx.WithTxRetry(2))
+
+	// A read in a repository method — DB(ctx) returns the ambient tx or the pool:
+	_ = func(ctx context.Context, id string) error {
+		var name string
+		err := client.DB(ctx).QueryRow(ctx, `SELECT name FROM things WHERE id = $1`, id).Scan(&name)
+		if err != nil {
+			return pgxx.MapError(err) // pgx.ErrNoRows -> rerror.ErrNotFound
+		}
+		return nil
+	}
+
+	// An atomic multi-write across repositories that share this Client and ctx:
+	_ = client.WithinTransaction(context.Background(), func(ctx context.Context) error {
+		// repoA.Save(ctx, ...) and repoB.Save(ctx, ...) both run on the same tx.
+		return nil
+	})
+}

--- a/pgxx/jsonb.go
+++ b/pgxx/jsonb.go
@@ -1,0 +1,25 @@
+package pgxx
+
+import "encoding/json"
+
+// MarshalJSONBSlice encodes a slice for a nullable jsonb column: an empty/nil
+// slice marshals to nil so the column stores SQL NULL rather than "[]".
+func MarshalJSONBSlice[T any](v []T) ([]byte, error) {
+	if len(v) == 0 {
+		return nil, nil
+	}
+	return json.Marshal(v)
+}
+
+// UnmarshalJSONBSlice decodes a nullable jsonb column into a slice. Empty/nil
+// input yields a nil slice (no error).
+func UnmarshalJSONBSlice[T any](b []byte) ([]T, error) {
+	if len(b) == 0 {
+		return nil, nil
+	}
+	var out []T
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/pgxx/jsonb_test.go
+++ b/pgxx/jsonb_test.go
@@ -1,0 +1,33 @@
+package pgxx_test
+
+import (
+	"testing"
+
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type kv struct {
+	K string
+	V int
+}
+
+func TestJSONBSlice_RoundTrip(t *testing.T) {
+	in := []kv{{"a", 1}, {"b", 2}}
+	b, err := pgxx.MarshalJSONBSlice(in)
+	require.NoError(t, err)
+	out, err := pgxx.UnmarshalJSONBSlice[kv](b)
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+func TestJSONBSlice_EmptyNil(t *testing.T) {
+	b, err := pgxx.MarshalJSONBSlice[kv](nil)
+	require.NoError(t, err)
+	assert.Nil(t, b)
+
+	out, err := pgxx.UnmarshalJSONBSlice[kv](nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}

--- a/pgxx/keyset.go
+++ b/pgxx/keyset.go
@@ -1,0 +1,113 @@
+package pgxx
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/reearth/reearthx/usecasex"
+)
+
+// KeysetPaginate runs single-column keyset (Relay-style) pagination driven by
+// usecasex.CursorPagination — the SQL analogue of mongox cursor pagination.
+//
+// keyCol must be a unique, sortable column (typically the primary key); a row's
+// cursor IS that column's value, which cursorOf returns. table is the FROM
+// target (e.g. "triggers"), columns the SELECT list (e.g. "*" or "id, name"),
+// where an optional predicate WITHOUT the "WHERE" keyword (may be ""), and args
+// the placeholders referenced by where ($1..$len(args)).
+//
+// It runs a COUNT over the filtered set (TotalCount), then a keyset page query,
+// and returns rows in ascending keyCol order with a usecasex.PageInfo:
+//   - First (+optional After) → forward page; Last (+optional Before) → backward.
+//   - hasMore is detected with a LIMIT n+1 probe; the extra row is trimmed.
+func KeysetPaginate[T any](
+	ctx context.Context,
+	db DBTX,
+	table, columns, where string,
+	args []any,
+	keyCol string,
+	p *usecasex.CursorPagination,
+	scan pgx.RowToFunc[T],
+	cursorOf func(T) usecasex.Cursor,
+) ([]T, *usecasex.PageInfo, error) {
+	whereClause := func(extra ...string) string {
+		conds := make([]string, 0, len(extra)+1)
+		if where != "" {
+			conds = append(conds, where)
+		}
+		for _, e := range extra {
+			if e != "" {
+				conds = append(conds, e)
+			}
+		}
+		if len(conds) == 0 {
+			return ""
+		}
+		return " WHERE " + strings.Join(conds, " AND ")
+	}
+
+	var total int64
+	if err := db.QueryRow(ctx, "SELECT count(*) FROM "+table+whereClause(), args...).Scan(&total); err != nil {
+		return nil, nil, WrapError(err)
+	}
+
+	// Forward unless Last is the only bound set.
+	forward := p == nil || p.First != nil || p.Last == nil
+	pageArgs := append([]any{}, args...)
+
+	var boundary, order string
+	var limited bool
+	var limit int64
+	if forward {
+		if p != nil && p.After != nil {
+			pageArgs = append(pageArgs, string(*p.After))
+			boundary = fmt.Sprintf("%s > $%d", keyCol, len(pageArgs))
+		}
+		order = " ORDER BY " + keyCol + " ASC"
+		if p != nil && p.First != nil {
+			limited, limit = true, *p.First
+		}
+	} else {
+		if p.Before != nil {
+			pageArgs = append(pageArgs, string(*p.Before))
+			boundary = fmt.Sprintf("%s < $%d", keyCol, len(pageArgs))
+		}
+		order = " ORDER BY " + keyCol + " DESC"
+		if p.Last != nil {
+			limited, limit = true, *p.Last
+		}
+	}
+
+	q := "SELECT " + columns + " FROM " + table + whereClause(boundary) + order
+	if limited {
+		pageArgs = append(pageArgs, limit+1) // +1 to detect hasMore
+		q += fmt.Sprintf(" LIMIT $%d", len(pageArgs))
+	}
+
+	list, err := List[T](ctx, db, q, pageArgs, scan)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hasMore := limited && int64(len(list)) > limit
+	if hasMore {
+		list = list[:limit]
+	}
+	if !forward { // queried DESC; restore ascending keyCol order
+		for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+			list[i], list[j] = list[j], list[i]
+		}
+	}
+	hasNext := (forward && hasMore) || (!forward && p != nil && p.Before != nil)
+	hasPrev := (!forward && hasMore) || (forward && p != nil && p.After != nil)
+
+	var start, end *usecasex.Cursor
+	if len(list) > 0 {
+		s := cursorOf(list[0])
+		e := cursorOf(list[len(list)-1])
+		start, end = &s, &e
+	}
+	return list, usecasex.NewPageInfo(total, start, end, hasNext, hasPrev), nil
+}

--- a/pgxx/keyset_test.go
+++ b/pgxx/keyset_test.go
@@ -1,0 +1,82 @@
+package pgxx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/pgxx/pgxtest"
+	"github.com/reearth/reearthx/usecasex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ksRow struct{ ID string }
+
+func ksCursor(r ksRow) usecasex.Cursor { return usecasex.Cursor(r.ID) }
+
+func setupKeyset(t *testing.T) (context.Context, pgxx.DBTX) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `CREATE TABLE ks (id text PRIMARY KEY)`)
+	require.NoError(t, err)
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		_, e := pool.Exec(ctx, `INSERT INTO ks (id) VALUES ($1)`, id)
+		require.NoError(t, e)
+	}
+	return ctx, pgxx.NewClient(pool).DB(ctx)
+}
+
+func keyset(t *testing.T, ctx context.Context, db pgxx.DBTX, p *usecasex.CursorPagination) ([]ksRow, *usecasex.PageInfo) {
+	rows, info, err := pgxx.KeysetPaginate[ksRow](ctx, db, "ks", "id", "", nil, "id", p, pgx.RowToStructByPos[ksRow], ksCursor)
+	require.NoError(t, err)
+	return rows, info
+}
+
+func ids(rows []ksRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.ID
+	}
+	return out
+}
+
+func TestKeysetPaginate_Forward(t *testing.T) {
+	ctx, db := setupKeyset(t)
+	n := int64(2)
+	rows, info := keyset(t, ctx, db, &usecasex.CursorPagination{First: &n})
+	assert.Equal(t, []string{"a", "b"}, ids(rows))
+	assert.Equal(t, int64(5), info.TotalCount)
+	assert.True(t, info.HasNextPage)
+	assert.False(t, info.HasPreviousPage)
+	assert.Equal(t, usecasex.Cursor("a"), *info.StartCursor)
+	assert.Equal(t, usecasex.Cursor("b"), *info.EndCursor)
+}
+
+func TestKeysetPaginate_ForwardAfter(t *testing.T) {
+	ctx, db := setupKeyset(t)
+	n, after := int64(2), usecasex.Cursor("b")
+	rows, info := keyset(t, ctx, db, &usecasex.CursorPagination{First: &n, After: &after})
+	assert.Equal(t, []string{"c", "d"}, ids(rows))
+	assert.True(t, info.HasNextPage)     // "e" remains
+	assert.True(t, info.HasPreviousPage) // After set
+}
+
+func TestKeysetPaginate_Backward(t *testing.T) {
+	ctx, db := setupKeyset(t)
+	n := int64(2)
+	rows, info := keyset(t, ctx, db, &usecasex.CursorPagination{Last: &n})
+	assert.Equal(t, []string{"d", "e"}, ids(rows)) // ascending order restored
+	assert.True(t, info.HasPreviousPage)           // more before "d"
+	assert.False(t, info.HasNextPage)
+}
+
+func TestKeysetPaginate_BackwardBefore(t *testing.T) {
+	ctx, db := setupKeyset(t)
+	n, before := int64(2), usecasex.Cursor("d")
+	rows, info := keyset(t, ctx, db, &usecasex.CursorPagination{Last: &n, Before: &before})
+	assert.Equal(t, []string{"b", "c"}, ids(rows))
+	assert.True(t, info.HasNextPage)     // Before set
+	assert.True(t, info.HasPreviousPage) // "a" remains before "b"
+}

--- a/pgxx/lock.go
+++ b/pgxx/lock.go
@@ -1,0 +1,59 @@
+package pgxx
+
+import (
+	"context"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Unlock releases an advisory lock and returns the held connection to the pool.
+type Unlock func(context.Context) error
+
+// AdvisoryLock acquires a session-level Postgres advisory lock on key, blocking
+// until it is available. It holds a dedicated pooled connection for the lock's
+// lifetime; call the returned Unlock to release the lock and the connection.
+func AdvisoryLock(ctx context.Context, pool *pgxpool.Pool, key int64) (Unlock, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock($1)`, key); err != nil {
+		conn.Release()
+		return nil, WrapError(err)
+	}
+	return unlocker(conn, key), nil
+}
+
+// TryAdvisoryLock attempts to acquire the advisory lock without blocking. If the
+// lock is already held (by any session), it returns acquired=false and a nil
+// Unlock. On success it returns an Unlock as in AdvisoryLock.
+func TryAdvisoryLock(ctx context.Context, pool *pgxpool.Pool, key int64) (Unlock, bool, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, false, WrapError(err)
+	}
+	var ok bool
+	if err := conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, key).Scan(&ok); err != nil {
+		conn.Release()
+		return nil, false, WrapError(err)
+	}
+	if !ok {
+		conn.Release()
+		return nil, false, nil
+	}
+	return unlocker(conn, key), true, nil
+}
+
+func unlocker(conn *pgxpool.Conn, key int64) Unlock {
+	var once sync.Once
+	return func(ctx context.Context) error {
+		var err error
+		once.Do(func() {
+			defer conn.Release()
+			_, e := conn.Exec(ctx, `SELECT pg_advisory_unlock($1)`, key)
+			err = WrapError(e)
+		})
+		return err // second and later calls are no-ops returning nil
+	}
+}

--- a/pgxx/lock_test.go
+++ b/pgxx/lock_test.go
@@ -1,0 +1,33 @@
+package pgxx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/pgxx/pgxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdvisoryLock(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	const key int64 = 0x52454143
+
+	unlock, err := pgxx.AdvisoryLock(ctx, pool, key)
+	require.NoError(t, err)
+
+	// While held, a non-blocking try from another session must fail.
+	u2, ok, err := pgxx.TryAdvisoryLock(ctx, pool, key)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, u2)
+
+	// After release, the lock is acquirable again.
+	require.NoError(t, unlock(ctx))
+	u3, ok, err := pgxx.TryAdvisoryLock(ctx, pool, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, u3(ctx))
+}

--- a/pgxx/maperror_test.go
+++ b/pgxx/maperror_test.go
@@ -1,0 +1,21 @@
+package pgxx_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/rerror"
+	"github.com/reearth/reearthx/usecasex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapError(t *testing.T) {
+	assert.Nil(t, pgxx.MapError(nil))
+	assert.ErrorIs(t, pgxx.MapError(pgx.ErrNoRows), rerror.ErrNotFound)
+	assert.ErrorIs(t, pgxx.MapError(&pgconn.PgError{Code: "40001"}), usecasex.ErrTransaction)
+	other := errors.New("boom")
+	assert.Equal(t, other, pgxx.MapError(other))
+}

--- a/pgxx/pagination.go
+++ b/pgxx/pagination.go
@@ -1,0 +1,57 @@
+package pgxx
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// CountAndList runs an offset-paginated query: it executes countSQL to get the
+// total, then runs listSQL with `LIMIT $n OFFSET $m` appended (the caller must
+// NOT include LIMIT/OFFSET in listSQL), scanning rows into []T via scan
+// (e.g. pgx.RowToStructByPos[gen.Foo]). countSQL and listSQL share the same
+// leading args. Callers map total into their own page-info type
+// (interfaces.PageBasedInfo, usecasex.PageInfo, …).
+func CountAndList[T any](
+	ctx context.Context,
+	db DBTX,
+	countSQL, listSQL string,
+	args []any,
+	limit, offset int64,
+	scan pgx.RowToFunc[T],
+) ([]T, int64, error) {
+	var total int64
+	if err := db.QueryRow(ctx, countSQL, args...).Scan(&total); err != nil {
+		return nil, 0, WrapError(err)
+	}
+
+	pageArgs := append(append([]any{}, args...), limit, offset)
+	q := fmt.Sprintf("%s LIMIT $%d OFFSET $%d", listSQL, len(args)+1, len(args)+2)
+	rows, err := db.Query(ctx, q, pageArgs...)
+	if err != nil {
+		return nil, 0, WrapError(err)
+	}
+	defer rows.Close()
+
+	list, err := pgx.CollectRows(rows, scan)
+	if err != nil {
+		return nil, 0, WrapError(err)
+	}
+	return list, total, nil
+}
+
+// List runs a non-paginated query and scans rows into []T via scan.
+func List[T any](ctx context.Context, db DBTX, sql string, args []any, scan pgx.RowToFunc[T]) ([]T, error) {
+	rows, err := db.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+	defer rows.Close()
+
+	list, err := pgx.CollectRows(rows, scan)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+	return list, nil
+}

--- a/pgxx/pagination_test.go
+++ b/pgxx/pagination_test.go
@@ -1,0 +1,42 @@
+package pgxx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/pgxx/pgxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type pagItem struct {
+	ID string
+}
+
+func TestCountAndList(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `CREATE TABLE items (id text PRIMARY KEY)`)
+	require.NoError(t, err)
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		_, err := pool.Exec(ctx, `INSERT INTO items (id) VALUES ($1)`, id)
+		require.NoError(t, err)
+	}
+	db := pgxx.NewClient(pool).DB(ctx)
+
+	rows, total, err := pgxx.CountAndList[pagItem](ctx, db,
+		`SELECT count(*) FROM items`,
+		`SELECT * FROM items ORDER BY id`,
+		nil, 2, 2, pgx.RowToStructByPos[pagItem])
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), total)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "c", rows[0].ID)
+	assert.Equal(t, "d", rows[1].ID)
+
+	all, err := pgxx.List[pagItem](ctx, db, `SELECT * FROM items ORDER BY id`, nil, pgx.RowToStructByPos[pagItem])
+	require.NoError(t, err)
+	assert.Len(t, all, 5)
+}

--- a/pgxx/pgxtest/apply.go
+++ b/pgxx/pgxtest/apply.go
@@ -1,0 +1,43 @@
+package pgxtest
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ApplyFS executes every *.sql file in fsys (lexical order) against pool. It is
+// for test setup: point it at an embedded or on-disk migrations directory
+// (os.DirFS / embed.FS) to materialize the schema on a fresh test database.
+// Non-".sql" files (e.g. atlas.sum) are ignored. Each file is run as a single
+// Exec, so multi-statement files work via the simple protocol.
+func ApplyFS(ctx context.Context, pool *pgxpool.Pool, fsys fs.FS) error {
+	var files []string
+	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".sql") {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("pgxtest: walk migrations: %w", err)
+	}
+	sort.Strings(files)
+
+	for _, f := range files {
+		b, err := fs.ReadFile(fsys, f)
+		if err != nil {
+			return fmt.Errorf("pgxtest: read %s: %w", f, err)
+		}
+		if _, err := pool.Exec(ctx, string(b)); err != nil {
+			return fmt.Errorf("pgxtest: apply %s: %w", f, err)
+		}
+	}
+	return nil
+}

--- a/pgxx/pgxtest/apply_test.go
+++ b/pgxx/pgxtest/apply_test.go
@@ -1,0 +1,26 @@
+package pgxtest_test
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/reearth/reearthx/pgxx/pgxtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyFS(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+
+	fsys := fstest.MapFS{
+		"0001_init.sql": &fstest.MapFile{Data: []byte(`CREATE TABLE things (id text PRIMARY KEY);`)},
+		"atlas.sum":     &fstest.MapFile{Data: []byte("ignored\n")}, // non-.sql must be skipped
+	}
+	require.NoError(t, pgxtest.ApplyFS(ctx, pool, fsys))
+
+	var n int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM things`).Scan(&n))
+	assert.Equal(t, 0, n)
+}

--- a/pgxx/pgxtest/pgxtest.go
+++ b/pgxx/pgxtest/pgxtest.go
@@ -1,0 +1,73 @@
+// Package pgxtest provides an env-gated Postgres connection for tests, mirroring
+// reearthx/mongox/mongotest: tests skip when no DB URI is configured, and each
+// call creates an isolated, uniquely-named database that is dropped on cleanup.
+package pgxtest
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Env is the environment variable holding an admin Postgres URI
+// (e.g. postgres://user:pass@localhost:5432/postgres?sslmode=disable).
+var Env = "REEARTH_DB_PG"
+
+// Connect returns a factory that yields an isolated *pgxpool.Pool per call.
+// It t.Skip()s when Env is unset, matching mongotest semantics.
+func Connect(t *testing.T) func(*testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	adminURI := os.Getenv(Env)
+	if adminURI == "" {
+		t.Skipf("pgxtest: %s not set; skipping Postgres integration test", Env)
+		return nil
+	}
+
+	ctx := context.Background()
+	admin, err := pgxpool.New(ctx, adminURI)
+	if err != nil {
+		t.Fatalf("pgxtest: connect admin: %v", err)
+	}
+	t.Cleanup(admin.Close)
+
+	if err := admin.Ping(ctx); err != nil {
+		t.Fatalf("pgxtest: ping admin db: %v", err)
+	}
+
+	return func(t *testing.T) *pgxpool.Pool {
+		t.Helper()
+
+		dbName := "reearth_test_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+		if _, err := admin.Exec(ctx, "CREATE DATABASE "+dbName); err != nil {
+			t.Fatalf("pgxtest: create database: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = admin.Exec(ctx, "DROP DATABASE IF EXISTS "+dbName+" WITH (FORCE)")
+		})
+
+		pool, err := pgxpool.New(ctx, replaceDBName(adminURI, dbName))
+		if err != nil {
+			t.Fatalf("pgxtest: connect test db: %v", err)
+		}
+		t.Cleanup(pool.Close)
+		return pool
+	}
+}
+
+// replaceDBName swaps the path component (database name) of a Postgres URI,
+// preserving userinfo, host, and query string. It uses net/url so it handles
+// edge cases (escaped credentials, missing path) robustly.
+func replaceDBName(uri, dbName string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		panic("pgxtest: invalid Postgres URI: " + err.Error())
+	}
+	u.Path = "/" + dbName
+	return u.String()
+}

--- a/pgxx/pgxx.go
+++ b/pgxx/pgxx.go
@@ -1,0 +1,45 @@
+// Package pgxx provides reusable PostgreSQL building blocks for reearth services,
+// the Postgres analogue of mongox: a Client (executor-from-context + a composing
+// WithinTransaction that implements usecasex.Transactor), the DBTX query surface
+// shared with sqlc's pgx/v5 output, error helpers, and an env-gated test connector.
+package pgxx
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// DBTX is the minimal query surface shared by *pgxpool.Pool and pgx.Tx.
+// It matches the interface sqlc generates for the pgx/v5 driver, so a value of
+// this type is assignable to a generated package's DBTX parameter.
+type DBTX interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...any) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+type txKey struct{}
+
+// ContextWithTx returns a copy of ctx carrying tx. Used by Client.WithinTransaction;
+// exported so tests (and advanced callers) can inject a transaction.
+func ContextWithTx(ctx context.Context, tx pgx.Tx) context.Context {
+	return context.WithValue(ctx, txKey{}, tx)
+}
+
+func txFromContext(ctx context.Context) (pgx.Tx, bool) {
+	tx, ok := ctx.Value(txKey{}).(pgx.Tx)
+	return tx, ok
+}
+
+// Executor returns the active transaction stored in ctx if present, otherwise
+// the supplied db (typically a *pgxpool.Pool). Repositories build their sqlc
+// Queries with Executor(ctx, pool) so writes inside a usecasex.Transactor run
+// on the transaction's connection automatically.
+func Executor(ctx context.Context, db DBTX) DBTX {
+	if tx, ok := txFromContext(ctx); ok {
+		return tx
+	}
+	return db
+}

--- a/pgxx/pgxx_test.go
+++ b/pgxx/pgxx_test.go
@@ -1,0 +1,27 @@
+package pgxx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecutor_ReturnsPoolWhenNoTx(t *testing.T) {
+	var pool *pgxpool.Pool // nil pool is fine; we only check identity, not use
+	got := pgxx.Executor(context.Background(), pool)
+	assert.Equal(t, pgxx.DBTX(pool), got)
+}
+
+func TestExecutor_ReturnsTxFromContext(t *testing.T) {
+	ctx := pgxx.ContextWithTx(context.Background(), fakeTx{})
+	got := pgxx.Executor(ctx, (*pgxpool.Pool)(nil))
+	_, isFake := got.(fakeTx)
+	assert.True(t, isFake, "Executor must return the tx stored in context")
+}
+
+// fakeTx embeds pgx.Tx so it satisfies the interface without implementing every method.
+type fakeTx struct{ pgx.Tx }

--- a/usecasex/migration/client.go
+++ b/usecasex/migration/client.go
@@ -13,9 +13,11 @@ import (
 )
 
 type Key = int64
-type MigrationFunc[C DBClient] func(context.Context, C) error
-type Migrations[C DBClient] map[Key]MigrationFunc[C]
+type MigrationFunc[C any] func(context.Context, C) error
+type Migrations[C any] map[Key]MigrationFunc[C]
 
+// DBClient is the dependency of the legacy Client (Begin/Commit/End transactions,
+// e.g. Mongo). New backends should prefer Runner, which takes a usecasex.Transactor.
 type DBClient interface {
 	Transaction() usecasex.Transaction
 }
@@ -73,6 +75,62 @@ func (c Client[C]) Migrate(ctx context.Context) (err error) {
 			}
 
 			return c.config.Save(ctx, m)
+		}); err != nil {
+			return fmt.Errorf("failed to exec migration %d: %w", m, rerror.UnwrapErrInternalOr(err))
+		}
+	}
+
+	return nil
+}
+
+// Runner is a usecasex.Transactor-based migration runner. It is the successor to
+// Client for backends that use the WithinTransaction callback (e.g. Postgres via
+// pgxx.Client). Mongo continues to use Client until it is migrated over.
+type Runner[C any] struct {
+	transactor usecasex.Transactor
+	client     C
+	config     ConfigRepo
+	migrations Migrations[C]
+}
+
+func NewRunner[C any](transactor usecasex.Transactor, client C, config ConfigRepo, migrations Migrations[C]) *Runner[C] {
+	return &Runner[C]{
+		transactor: transactor,
+		client:     client,
+		config:     config,
+		migrations: migrations,
+	}
+}
+
+func (r Runner[C]) Migrate(ctx context.Context) (err error) {
+	if err := r.config.Begin(ctx); err != nil {
+		return err
+	}
+
+	defer func() {
+		if err2 := r.config.End(ctx); err == nil && err2 != nil {
+			err = err2
+		}
+	}()
+
+	current, err := r.config.Current(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", rerror.UnwrapErrInternal(err))
+	}
+
+	nextMigrations := nextMigration(lo.Keys(r.migrations), current)
+	if len(nextMigrations) == 0 {
+		return nil
+	}
+
+	for _, m := range nextMigrations {
+		log.Infofc(ctx, "DB migration: %d\n", m)
+		if err := r.transactor.WithinTransaction(ctx, func(ctx context.Context) error {
+			if err := r.migrations[m](ctx, r.client); err != nil {
+				return err
+			}
+
+			return r.config.Save(ctx, m)
 		}); err != nil {
 			return fmt.Errorf("failed to exec migration %d: %w", m, rerror.UnwrapErrInternalOr(err))
 		}

--- a/usecasex/migration/doc.go
+++ b/usecasex/migration/doc.go
@@ -1,0 +1,16 @@
+// Package migration runs versioned database migrations keyed by an integer
+// version that is tracked in a ConfigRepo.
+//
+// Two runners share the same Migrations/ConfigRepo machinery:
+//
+//   - Client is the original runner for backends that expose
+//     usecasex.Transaction (Begin/Commit/End) — e.g. Mongo.
+//   - Runner is the successor for backends that expose usecasex.Transactor
+//     (WithinTransaction) — e.g. Postgres via pgxx.Client. New backends should
+//     use Runner; Client remains for Mongo until it is migrated over.
+//
+// Both apply pending Migrations in ascending version order, each inside its own
+// transaction. The ConfigRepo persists the current version: Begin/End wrap the
+// whole run (e.g. to acquire and release a lock), Current reports the applied
+// version, and Save records each newly-applied version.
+package migration

--- a/usecasex/migration/runner_integration_test.go
+++ b/usecasex/migration/runner_integration_test.go
@@ -1,0 +1,47 @@
+package migration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/reearth/reearthx/pgxx"
+	"github.com/reearth/reearthx/pgxx/pgxtest"
+	"github.com/reearth/reearthx/usecasex/migration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memConfig is an in-memory ConfigRepo for exercising Runner against a real DB.
+type memConfig struct{ cur migration.Key }
+
+func (m *memConfig) Begin(context.Context) error                    { return nil }
+func (m *memConfig) End(context.Context) error                      { return nil }
+func (m *memConfig) Current(context.Context) (migration.Key, error) { return m.cur, nil }
+func (m *memConfig) Save(_ context.Context, k migration.Key) error  { m.cur = k; return nil }
+
+// Runner driven by a real pgxx.Client (the deployed Postgres combination):
+// migrations run inside real transactions, the version is tracked, and a
+// re-run is idempotent.
+func TestRunner_RealClient_AppliesAndIdempotent(t *testing.T) {
+	pool := pgxtest.Connect(t)(t)
+	ctx := context.Background()
+	client := pgxx.NewClient(pool)
+	cfg := &memConfig{}
+
+	runs := 0
+	migs := migration.Migrations[*pgxx.Client]{
+		1: func(ctx context.Context, c *pgxx.Client) error {
+			runs++
+			_, err := c.DB(ctx).Exec(ctx, `CREATE TABLE mig_real (id integer)`)
+			return err
+		},
+	}
+	r := migration.NewRunner[*pgxx.Client](client, client, cfg, migs)
+
+	require.NoError(t, r.Migrate(ctx))
+	assert.Equal(t, 1, runs)
+	assert.Equal(t, migration.Key(1), cfg.cur)
+
+	require.NoError(t, r.Migrate(ctx)) // already at version 1 -> no-op
+	assert.Equal(t, 1, runs)
+}

--- a/usecasex/migration/runner_test.go
+++ b/usecasex/migration/runner_test.go
@@ -1,0 +1,47 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/reearth/reearthx/usecasex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunner(t *testing.T) {
+	ctx := context.Background()
+	tr := usecasex.NewTransactor(&usecasex.NopTransaction{}, 0)
+	r := &dummyRepo{}
+	cl := &dummyClient{}
+	calls := []Key{}
+	m := Migrations[*dummyClient]{
+		10: func(ctx context.Context, c *dummyClient) error { calls = append(calls, 10); return nil },
+		20: func(ctx context.Context, c *dummyClient) error { calls = append(calls, 20); return nil },
+		30: func(ctx context.Context, c *dummyClient) error { calls = append(calls, 30); return nil },
+		40: func(ctx context.Context, c *dummyClient) error { calls = append(calls, 40); return nil },
+	}
+	run := NewRunner[*dummyClient](tr, cl, r, m)
+
+	assert.NoError(t, run.Migrate(ctx))
+	assert.Equal(t, 1, r.beginCalls)
+	assert.Equal(t, 1, r.endCalls)
+	assert.Equal(t, []Key{30, 40}, r.saveCalls) // dummyRepo.Current() == 20
+	assert.Equal(t, []Key{30, 40}, calls)
+}
+
+func TestRunnerError(t *testing.T) {
+	ctx := context.Background()
+	tr := usecasex.NewTransactor(&usecasex.NopTransaction{}, 0)
+	r := &dummyRepo{}
+	calls := []Key{}
+	er := errors.New("ERR!")
+	m := Migrations[*dummyClient]{
+		30: func(ctx context.Context, c *dummyClient) error { calls = append(calls, 30); return er },
+	}
+	run := NewRunner[*dummyClient](tr, &dummyClient{}, r, m)
+
+	assert.EqualError(t, run.Migrate(ctx), "failed to exec migration 30: ERR!")
+	assert.Nil(t, r.saveCalls)
+	assert.Equal(t, []Key{30}, calls)
+}

--- a/usecasex/transactor.go
+++ b/usecasex/transactor.go
@@ -1,0 +1,26 @@
+package usecasex
+
+import "context"
+
+// Transactor runs a function within a database transaction, committing on a nil
+// return and rolling back on error. The fn receives a context carrying the
+// transaction; repositories resolve it (e.g. via pgxx.Executor) transparently.
+type Transactor interface {
+	WithinTransaction(ctx context.Context, fn func(ctx context.Context) error) error
+}
+
+// NewTransactor adapts an existing Transaction (e.g. the Mongo implementation)
+// into a Transactor, delegating to DoTransaction so retry-on-ErrTransaction
+// behavior is preserved. retry <= 0 means a single attempt.
+func NewTransactor(t Transaction, retry int) Transactor {
+	return &transactorAdapter{t: t, retry: retry}
+}
+
+type transactorAdapter struct {
+	t     Transaction
+	retry int
+}
+
+func (a *transactorAdapter) WithinTransaction(ctx context.Context, fn func(ctx context.Context) error) error {
+	return DoTransaction(ctx, a.t, a.retry, fn)
+}

--- a/usecasex/transactor_test.go
+++ b/usecasex/transactor_test.go
@@ -1,0 +1,36 @@
+package usecasex_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/reearth/reearthx/usecasex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactor_RunsAndReturns(t *testing.T) {
+	tr := usecasex.NewTransactor(&usecasex.NopTransaction{}, 0)
+	ran := false
+	err := tr.WithinTransaction(context.Background(), func(ctx context.Context) error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ran)
+}
+
+func TestTransactor_RetriesOnErrTransaction(t *testing.T) {
+	tr := usecasex.NewTransactor(&usecasex.NopTransaction{}, 2)
+	calls := 0
+	err := tr.WithinTransaction(context.Background(), func(ctx context.Context) error {
+		calls++
+		if calls == 1 {
+			return errors.Join(usecasex.ErrTransaction, errors.New("conflict"))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}


### PR DESCRIPTION
## Summary

Adds a reusable transaction abstraction and pgx-backed Postgres building blocks, following the "SQL transactions in Go the good way" callback pattern.

- **`usecasex.Transactor`** — new canonical interface: `WithinTransaction(ctx, func(ctx) error) error` (commit on nil return, rollback on error). The context passed to the callback carries the transaction.
- **`usecasex.NewTransactor(t Transaction, retry)`** — bridges the existing `usecasex.Transaction` (e.g. the Mongo impl) into a `Transactor` via `DoTransaction`, preserving retry-on-`ErrTransaction`. Lets current backends adopt `WithinTransaction` with no new code.
- **`pgxx`** — implements `usecasex.Transactor` natively (begins a `pgx.Tx`, stores it in context for `Executor`/DBGetter to resolve in repositories, commits/rolls back, retries on serialization failure). `pgxx.Executor`, `WrapError`/`IsSerializationError`, and the env-gated `pgxtest` connector remain.

`usecasex.Transaction` is left intact (still used by the account package); this PR adds `Transactor` alongside it. `pgxx` no longer implements `usecasex.Transaction`.

This is the foundation for the reearth-flow Postgres "golden path" (consumed there via the Trigger pilot and a full interactor migration to `WithinTransaction`).

## Test Plan

- [ ] `go build ./... && go vet ./usecasex/ ./pgxx/...` clean
- [ ] `go test ./usecasex/ -run Transactor` (bridge runs fn; retries on ErrTransaction)
- [ ] Without a DB: `go test ./pgxx/...` — unit pass, integration skip
- [ ] With a DB: `REEARTH_DB_PG=... go test ./pgxx/...` — WithinTransaction commits on success, rolls back on error

## Note for reviewers

Branch cut from `5abca579aec6` (the commit reearth-flow consumes, `go 1.24.2`) rather than current `main` (`go 1.26.2`) to stay buildable by the consumer during development; consider rebasing onto `main` and reconciling `go.mod` before merge.