### PR TITLE
fix(pgxx): omit missing IDs in OrderByIDs; roll back on panic in WithinTransaction

### DIFF
--- a/pgxx/client.go
+++ b/pgxx/client.go
@@ -73,8 +73,12 @@ func (c *Client) runOnce(ctx context.Context, fn func(ctx context.Context) error
 	if err != nil {
 		return rerror.ErrInternalByWithContext(ctx, err)
 	}
+	// Roll back on any early return or panic; a no-op after a successful Commit
+	// (the tx is already closed). Without it, a panic in fn would skip the
+	// rollback and leak the pooled connection, eventually exhausting the pool.
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	if err := fn(ContextWithTx(ctx, tx)); err != nil {
-		_ = tx.Rollback(ctx)
 		return err
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/pgxx/client_test.go
+++ b/pgxx/client_test.go
@@ -67,3 +67,25 @@ func TestClient_WithinTransaction_NestedComposes(t *testing.T) {
 	require.ErrorIs(t, err, sentinel)
 	assert.Equal(t, 0, count(ctx), "nested insert must roll back with the outer tx")
 }
+
+// A panic inside the callback must roll back and release the pooled connection
+// (not leak it), so the panic propagates but the pool stays usable.
+func TestClient_WithinTransaction_ReleasesConnOnPanic(t *testing.T) {
+	ctx, c, count, insert := setupItems(t)
+
+	assert.Panics(t, func() {
+		_ = c.WithinTransaction(ctx, func(ctx context.Context) error {
+			if e := insert(ctx, "a"); e != nil {
+				return e
+			}
+			panic("boom")
+		})
+	})
+
+	assert.Equal(t, int32(0), c.Pool().Stat().AcquiredConns(), "connection leaked after panic")
+	assert.Equal(t, 0, count(ctx), "panic must roll back the insert")
+	require.NoError(t, c.WithinTransaction(ctx, func(ctx context.Context) error {
+		return insert(ctx, "b")
+	}), "pool must remain usable after a panic")
+	assert.Equal(t, 1, count(ctx))
+}

--- a/pgxx/collect.go
+++ b/pgxx/collect.go
@@ -1,20 +1,24 @@
 package pgxx
 
 // OrderByIDs reorders items to match the order of ids, matching each item by
-// key(item). An id with no matching item gets the zero value of T (nil for
-// pointer types). This is the FindByIDs contract repositories share: fetch rows
-// with `WHERE id = ANY($1)` (arbitrary order), then restore the requested order
-// with nil placeholders for missing ids.
+// key(item). Ids with no matching item are omitted (not padded with a zero
+// value), so the result contains only present items and never a nil element.
+// This is the FindByIDs contract repositories share, and it matches Mongo, whose
+// callers iterate the result without nil checks: fetch rows with
+// `WHERE id = ANY($1)` (arbitrary order), restore the requested order, and drop
+// ids that returned no row.
 //
-// Filter items (e.g. by workspace) before calling this; unmatched ids become nil.
+// Filter items (e.g. by workspace) before calling this; unmatched ids are dropped.
 func OrderByIDs[K comparable, T any](ids []K, items []T, key func(T) K) []T {
 	byID := make(map[K]T, len(items))
 	for _, it := range items {
 		byID[key(it)] = it
 	}
-	out := make([]T, len(ids))
-	for i, id := range ids {
-		out[i] = byID[id] // zero value (nil) when absent
+	out := make([]T, 0, len(items))
+	for _, id := range ids {
+		if it, ok := byID[id]; ok {
+			out = append(out, it)
+		}
 	}
 	return out
 }

--- a/pgxx/collect_test.go
+++ b/pgxx/collect_test.go
@@ -17,10 +17,10 @@ func TestOrderByIDs(t *testing.T) {
 	key := func(i *item) string { return i.id }
 
 	got := pgxx.OrderByIDs([]string{"a", "missing", "b"}, items, key)
-	assert.Len(t, got, 3)
+	// Missing ids are omitted (never a nil element), matching Mongo's FindByIDs.
+	assert.Len(t, got, 2)
 	assert.Equal(t, "A", got[0].name)
-	assert.Nil(t, got[1]) // missing id -> zero value (nil)
-	assert.Equal(t, "B", got[2].name)
+	assert.Equal(t, "B", got[1].name)
 }
 
 func TestIsUniqueViolation(t *testing.T) {

--- a/pgxx/coverage_test.go
+++ b/pgxx/coverage_test.go
@@ -125,10 +125,9 @@ func TestOrderByIDs_Edges(t *testing.T) {
 	items := []*item{{"a", "A"}, {"a", "A2"}} // duplicate key: last wins
 
 	got := pgxx.OrderByIDs([]string{"a", "a", "x"}, items, key)
-	require.Len(t, got, 3)
+	require.Len(t, got, 2) // missing id "x" is omitted (never a nil element)
 	assert.Equal(t, "A2", got[0].v)
 	assert.Equal(t, "A2", got[1].v) // duplicate id resolves to the same item
-	assert.Nil(t, got[2])           // missing id -> nil
 
 	assert.Empty(t, pgxx.OrderByIDs[string, *item](nil, nil, key))
 }


### PR DESCRIPTION
Two `pgxx` robustness bugs surfaced by running reearth-flow's full e2e GraphQL suite against the Postgres adapters (ported repos on Postgres, asset/account on Mongo, so the only variable was pgxx).

## 1. `OrderByIDs` returned `nil` elements for missing IDs
It built the result with `make([]T, len(ids))` and left the zero value (nil for pointer types) where an id had no matching row. The shared `FindByIDs` contract is consumed by Mongo-derived repositories whose callers iterate the result **without nil checks** (e.g. `RemoveParameters` does `param.ProjectID()`), so a missing id caused a nil-pointer panic → GraphQL "internal system error".

**Fix:** omit missing ids (matches Mongo's `FindByIDs`, which simply doesn't return absent ids). The result now contains only present items and never a nil element. Order is still the requested id order.

## 2. `WithinTransaction` leaked the connection on panic
`runOnce` rolled back only on a returned `error`. If the callback **panicked**, neither rollback nor commit ran, so the pooled connection was never released — `pgxpool.Close()` blocks forever, and in production a panic-in-transaction would exhaust the pool over time.

**Fix:** `defer` a rollback (a no-op after a successful commit), so a panic releases the connection and then propagates as before.

## Tests
- `TestOrderByIDs` / `TestOrderByIDs_Edges` updated to assert missing ids are omitted (no nil elements).
- New `TestClient_WithinTransaction_ReleasesConnOnPanic`: a panicking callback propagates the panic, rolls back the write, leaves `AcquiredConns()==0`, and the pool stays usable.

Full `pgxx` suite green on Postgres 18.