### PR TITLE
refactor(log): replace zapcore.Level with custom Level type for improved abstraction

### DIFF
--- a/log/echo.go
+++ b/log/echo.go
@@ -8,7 +8,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/gommon/log"
 	"github.com/reearth/reearthx/util"
-	"go.uber.org/zap/zapcore"
 )
 
 type Echo struct {
@@ -46,13 +45,13 @@ func (l *Echo) SetDynamicSuffix(suffix func() Format) {
 // Level returns logger level
 func (l *Echo) Level() log.Lvl {
 	switch l.logger.Level() {
-	case zapcore.DebugLevel:
+	case LevelDebug:
 		return log.DEBUG
-	case zapcore.InfoLevel:
+	case LevelInfo:
 		return log.INFO
-	case zapcore.WarnLevel:
+	case LevelWarn:
 		return log.WARN
-	case zapcore.ErrorLevel:
+	case LevelError:
 		return log.ERROR
 	default:
 		l.Panic("Invalid level")
@@ -78,13 +77,13 @@ func (l *Echo) Prefix() string {
 func (l *Echo) SetLevel(lvl log.Lvl) {
 	switch lvl {
 	case log.DEBUG:
-		l.logger.SetLevel(zapcore.DebugLevel)
+		l.logger.SetLevel(LevelDebug)
 	case log.INFO:
-		l.logger.SetLevel(zapcore.InfoLevel)
+		l.logger.SetLevel(LevelInfo)
 	case log.WARN:
-		l.logger.SetLevel(zapcore.WarnLevel)
+		l.logger.SetLevel(LevelWarn)
 	case log.ERROR:
-		l.logger.SetLevel(zapcore.ErrorLevel)
+		l.logger.SetLevel(LevelError)
 	}
 }
 

--- a/log/global.go
+++ b/log/global.go
@@ -2,15 +2,13 @@ package log
 
 import (
 	"io"
-
-	"go.uber.org/zap/zapcore"
 )
 
 var (
 	globalLogger = New().AddCallerSkip(1)
 )
 
-func SetLevel(l zapcore.Level) {
+func SetLevel(l Level) {
 	globalLogger.SetLevel(l)
 }
 

--- a/log/level.go
+++ b/log/level.go
@@ -1,0 +1,29 @@
+package log
+
+import "go.uber.org/zap/zapcore"
+
+// Level represents a logging severity, without exposing the underlying
+// zap/zapcore types to consumers of this package.
+type Level int8
+
+const (
+	LevelDebug  Level = Level(zapcore.DebugLevel)
+	LevelInfo   Level = Level(zapcore.InfoLevel)
+	LevelWarn   Level = Level(zapcore.WarnLevel)
+	LevelError  Level = Level(zapcore.ErrorLevel)
+	LevelDPanic Level = Level(zapcore.DPanicLevel)
+	LevelPanic  Level = Level(zapcore.PanicLevel)
+	LevelFatal  Level = Level(zapcore.FatalLevel)
+)
+
+func (l Level) String() string {
+	return l.zap().String()
+}
+
+func (l Level) zap() zapcore.Level {
+	return zapcore.Level(l)
+}
+
+func levelFromZap(l zapcore.Level) Level {
+	return Level(l)
+}

--- a/log/level_test.go
+++ b/log/level_test.go
@@ -1,0 +1,74 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestLevel_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		level Level
+		want  string
+	}{
+		{name: "debug", level: LevelDebug, want: "debug"},
+		{name: "info", level: LevelInfo, want: "info"},
+		{name: "warn", level: LevelWarn, want: "warn"},
+		{name: "error", level: LevelError, want: "error"},
+		{name: "dpanic", level: LevelDPanic, want: "dpanic"},
+		{name: "panic", level: LevelPanic, want: "panic"},
+		{name: "fatal", level: LevelFatal, want: "fatal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.level.String())
+		})
+	}
+}
+
+func TestLevel_zap(t *testing.T) {
+	tests := []struct {
+		name  string
+		level Level
+		want  zapcore.Level
+	}{
+		{name: "debug", level: LevelDebug, want: zapcore.DebugLevel},
+		{name: "info", level: LevelInfo, want: zapcore.InfoLevel},
+		{name: "warn", level: LevelWarn, want: zapcore.WarnLevel},
+		{name: "error", level: LevelError, want: zapcore.ErrorLevel},
+		{name: "dpanic", level: LevelDPanic, want: zapcore.DPanicLevel},
+		{name: "panic", level: LevelPanic, want: zapcore.PanicLevel},
+		{name: "fatal", level: LevelFatal, want: zapcore.FatalLevel},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.level.zap())
+		})
+	}
+}
+
+func TestLevelFromZap(t *testing.T) {
+	tests := []struct {
+		name string
+		in   zapcore.Level
+		want Level
+	}{
+		{name: "debug", in: zapcore.DebugLevel, want: LevelDebug},
+		{name: "info", in: zapcore.InfoLevel, want: LevelInfo},
+		{name: "warn", in: zapcore.WarnLevel, want: LevelWarn},
+		{name: "error", in: zapcore.ErrorLevel, want: LevelError},
+		{name: "dpanic", in: zapcore.DPanicLevel, want: LevelDPanic},
+		{name: "panic", in: zapcore.PanicLevel, want: LevelPanic},
+		{name: "fatal", in: zapcore.FatalLevel, want: LevelFatal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, levelFromZap(tt.in))
+		})
+	}
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -23,7 +23,7 @@ var (
 		EncodeCaller:   zapcore.ShortCallerEncoder,
 		EncodeName:     zapcore.FullNameEncoder,
 	}
-	DefaultLevel  = zap.DebugLevel
+	DefaultLevel  = LevelDebug
 	DefaultOutput = os.Stdout
 )
 
@@ -40,7 +40,7 @@ func New() *Logger {
 }
 
 func NewWithOutput(w io.Writer) *Logger {
-	atom := zap.NewAtomicLevelAt(DefaultLevel)
+	atom := zap.NewAtomicLevelAt(DefaultLevel.zap())
 	return &Logger{
 		logger: newLogger(w, atom, ""),
 		atom:   atom,
@@ -144,12 +144,12 @@ func (l *Logger) SetOutput(w io.Writer) *Logger {
 	}
 }
 
-func (l *Logger) Level() zapcore.Level {
-	return l.atom.Level()
+func (l *Logger) Level() Level {
+	return levelFromZap(l.atom.Level())
 }
 
-func (l *Logger) SetLevel(lv zapcore.Level) {
-	l.atom.SetLevel(lv)
+func (l *Logger) SetLevel(lv Level) {
+	l.atom.SetLevel(lv.zap())
 }
 
 func (l *Logger) Prefix() string {

--- a/log/slogger.go
+++ b/log/slogger.go
@@ -3,8 +3,6 @@ package log
 import (
 	"context"
 	"log/slog"
-
-	"go.uber.org/zap/zapcore"
 )
 
 // zapSlogHandler implements slog.Handler backed by *Logger.
@@ -25,18 +23,18 @@ func NewSlogLogger(l *Logger) *slog.Logger {
 }
 
 func (h *zapSlogHandler) Enabled(_ context.Context, level slog.Level) bool {
-	var zapLevel zapcore.Level
+	var lv Level
 	switch {
 	case level >= slog.LevelError:
-		zapLevel = zapcore.ErrorLevel
+		lv = LevelError
 	case level >= slog.LevelWarn:
-		zapLevel = zapcore.WarnLevel
+		lv = LevelWarn
 	case level >= slog.LevelInfo:
-		zapLevel = zapcore.InfoLevel
+		lv = LevelInfo
 	default:
-		zapLevel = zapcore.DebugLevel
+		lv = LevelDebug
 	}
-	return h.logger.Level() <= zapLevel
+	return h.logger.Level() <= lv
 }
 
 func (h *zapSlogHandler) Handle(_ context.Context, r slog.Record) error {


### PR DESCRIPTION
## Summary
- Introduce `log.Level`, a package-local type wrapping `zapcore.Level`, so consumers of the log package no longer need to import `go.uber.org/zap/zapcore` directly.
- Add `LevelDebug`, `LevelInfo`, `LevelWarn`, `LevelError`, `LevelDPanic`, `LevelPanic`, `LevelFatal` constants and a `String()` method.
- Update `Logger.Level()`/`SetLevel()`, the global `SetLevel()`, the Echo adapter, and the slog handler to use `log.Level` instead of `zapcore.Level`.

## Motivation
Exposing `zapcore.Level` in the public API ties the log package's interface to the zap implementation. Wrapping it in a local `Level` type keeps zap as an internal implementation detail and gives room to swap logging backends later without breaking callers.

## Test plan
- `go build ./...`
- `go test ./log/...`