### PR TITLE
feat(log): implement flag.Value on Level for direct use as a CLI flag

### DIFF
--- a/log/level.go
+++ b/log/level.go
@@ -1,10 +1,16 @@
 package log
 
-import "go.uber.org/zap/zapcore"
+import (
+	"flag"
+
+	"go.uber.org/zap/zapcore"
+)
 
 // Level represents a logging severity, without exposing the underlying
 // zap/zapcore types to consumers of this package.
 type Level int8
+
+var _ flag.Value = (*Level)(nil)
 
 const (
 	LevelDebug  Level = Level(zapcore.DebugLevel)
@@ -20,6 +26,16 @@ func (l Level) String() string {
 	return l.zap().String()
 }
 
+// Set implements flag.Value so Level can be used directly as a flag target.
+func (l *Level) Set(s string) error {
+	zl := l.zap()
+	if err := zl.Set(s); err != nil {
+		return err
+	}
+	*l = Level(zl)
+	return nil
+}
+
 func (l Level) zap() zapcore.Level {
 	return zapcore.Level(l)
 }
@@ -27,3 +43,4 @@ func (l Level) zap() zapcore.Level {
 func levelFromZap(l zapcore.Level) Level {
 	return Level(l)
 }
+

--- a/log/level_test.go
+++ b/log/level_test.go
@@ -51,6 +51,38 @@ func TestLevel_zap(t *testing.T) {
 	}
 }
 
+func TestLevel_Set(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial Level
+		in      string
+		want    Level
+		wantErr bool
+	}{
+		{name: "debug", initial: LevelError, in: "debug", want: LevelDebug},
+		{name: "info", initial: LevelError, in: "info", want: LevelInfo},
+		{name: "warn", initial: LevelError, in: "warn", want: LevelWarn},
+		{name: "error", initial: LevelDebug, in: "error", want: LevelError},
+		{name: "dpanic", initial: LevelDebug, in: "dpanic", want: LevelDPanic},
+		{name: "panic", initial: LevelDebug, in: "panic", want: LevelPanic},
+		{name: "fatal", initial: LevelDebug, in: "fatal", want: LevelFatal},
+		{name: "invalid", initial: LevelDebug, in: "invalid", wantErr: true, want: LevelDebug},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			l := tt.initial
+			err := l.Set(tt.in)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, l)
+		})
+	}
+}
+
 func TestLevelFromZap(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary
- Add `Level.Set(string) error`, implementing `flag.Value` alongside the existing `String()` method.
- `Set` delegates to `zapcore.Level`'s own `Set`, keeping zap as an internal detail while letting callers bind a `log.Level` directly to a `flag.FlagSet` (e.g. `flag.Var(&lvl, "log-level", "...")`).
- Add table-driven tests for `Set` covering all levels and the invalid-input error case, plus existing `String()`/`zap()`/`levelFromZap()` coverage in `log/level_test.go`.

## Motivation
Callers previously had to parse a log-level flag manually and convert it before calling `Logger.SetLevel`. Implementing `flag.Value` removes that boilerplate and matches the pattern `zapcore.Level` itself already supports.

## Test plan
- `go build ./...`
- `go test ./log/...`