### PR TITLE
chore(log): remove redundant doc comments

### DIFF
--- a/log/level.go
+++ b/log/level.go
@@ -6,8 +6,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// Level represents a logging severity, without exposing the underlying
-// zap/zapcore types to consumers of this package.
 type Level int8
 
 var _ flag.Value = (*Level)(nil)
@@ -26,7 +24,6 @@ func (l Level) String() string {
 	return l.zap().String()
 }
 
-// Set implements flag.Value so Level can be used directly as a flag target.
 func (l *Level) Set(s string) error {
 	zl := l.zap()
 	if err := zl.Set(s); err != nil {
@@ -43,4 +40,3 @@ func (l Level) zap() zapcore.Level {
 func levelFromZap(l zapcore.Level) Level {
 	return Level(l)
 }
-

--- a/log/slogger.go
+++ b/log/slogger.go
@@ -5,19 +5,16 @@ import (
 	"log/slog"
 )
 
-// zapSlogHandler implements slog.Handler backed by *Logger.
 type zapSlogHandler struct {
 	logger *Logger
 	attrs  []slog.Attr
 	group  string
 }
 
-// NewSlogHandler returns a slog.Handler backed by the given *Logger.
 func NewSlogHandler(l *Logger) slog.Handler {
 	return &zapSlogHandler{logger: l.AddCallerSkip(2)}
 }
 
-// NewSlogLogger returns a *slog.Logger backed by the given *Logger.
 func NewSlogLogger(l *Logger) *slog.Logger {
 	return slog.New(NewSlogHandler(l))
 }


### PR DESCRIPTION
## Summary
- Removes doc comments from `log/level.go` and `log/slogger.go` that merely restated what the code already makes obvious (type/function names).
- Trims a trailing blank line in `level.go`.

## Motivation
Keep the `log` package comment-free where comments don't add information beyond the identifier names, consistent with repo conventions favoring self-documenting code over restated docstrings.

## Test plan
- [x] No behavior change; comment-only removal.